### PR TITLE
Type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 This resository contains a work-in-progress implementation of LambdaPC, described in the following paper:
 
-> Jennifer Paykin and Sam Winnick. Qudit Quantum Programming with Projective Cliffords. 2026. https://arxiv.org/abs/2407.16801
+> Jennifer Paykin and Sam Winnick. Qudit Quantum Programming with Projective Cliffords. POPL 2026. https://arxiv.org/abs/2407.16801
 
 The structure of the library is as follows:
 
-* `lib/lambdaPC` - the top-level LambdaPC language, including evaluation
-* `lib/lambdaC` - the linear lambdaC language
-* `lib/scalars` - operations in the rings Z/Zd
+* `lib/interface` - top-level interface to LambdaPC programs via a simple parser and typechecker
 * `lib/examples` - example LambdaPC programs
-* `lib/interface` - interface to LambdaPC programs via a simple parser
+* `lib/lambdaPC` - the top-level LambdaPC language, including evaluation
+* `lib/typing` - type-checker for LambdaPC
+* `lib/lambdaC` - the linear lambdaC language
+* `lib/scalars` - operations on rings Z/Zd
 
 
 ### Syntax
@@ -47,7 +48,7 @@ Pauli expressions:
         | in1{tp} t | in2{tp} t                         (inject)
         | case t of {in1 x1 -> t1 | in2 x2 -> t2}       (multi-qubit case analysis)
         | c @ t                                         (apply a projective Clifford)
-    c ::= lambda x : tau. t                                ( projective Clifford expressions )
+    c ::= lambda x : tau. t                             (projective Clifford expressions)
 ```
 
 ### Use
@@ -55,17 +56,23 @@ Pauli expressions:
 Here is an example interaction with PCLib:
 
 ```
-    open PCLib.Interface
-    let had = pc "lambda q : Pauli. case q of {X -> Z | Z -> X}"
-    eval (had @ parse "Y")
+    # open PCLib.Interface;;
+    # set_dimension 4 (* default is 2 *);;
+    # let qft = pc "lambda q : Pauli. case q of { Z -> X^{-1} | X -> Z }"
+    # typecheck qft;;
+    # eval (qft @ parse "Y");;
 ```
 
 To interact with PCLib through the parser, use `open PCLib.Interface`. This exposes several important functions:
 
+* `set_dimension : int -> unit` - Sets the dimension to be used by the below functions. Dimension must be >1. Currently only instantiated for dimensions 2,3,4, but could easily be expanded.
 * `parse : string -> LambdaPC.Expr.t` - parse a string into a Pauli expression
 * `pc : string -> LambdaPC.Expr.pc` - parse a string into a projective Clifford function
-* `(*) : LambdaPC.Expr.pc -> LambdaPC.Expr.t -> LambdaPC.Expr.t` - apply a projective Clifford to a Pauli expression
+* `(@) : LambdaPC.Expr.pc -> LambdaPC.Expr.t -> LambdaPC.Expr.t` - apply a projective Clifford to a Pauli expression
 * `eval : LambdaPC.Expr.t -> unit` - pretty-print the input expression, evaluate it to a value, and then pretty-print the result
+* `leval : LambdaC.Expr.t -> unit` - pretty-print the input expression, evaluate it to a value, and then pretty-print the result
+* `typecheck : LambdaPC.Expr.pc -> unit` - typecheck the input projective Clifford and prints the result.
+* `omega : LambdaPC.Type.t -> LambdaPC.Expr.t -> LambdaPC.Expr.t -> unit` - evaluates omega applied to the psi components of the input LambdaPC expressions
 
 ## Installation
 

--- a/bin/dune
+++ b/bin/dune
@@ -6,3 +6,4 @@
 )
 
 (env (dev (flags (:standard -warn-error -A))))
+; (env (dev (flags (:standard))))

--- a/lib/dune
+++ b/lib/dune
@@ -8,4 +8,5 @@
 (library
  (name pCLib)
  (modules :standard)
+ (libraries smtml)
 )

--- a/lib/examples.ml
+++ b/lib/examples.ml
@@ -12,7 +12,7 @@ let pauliI_ tp = vec (LambdaC.HOAS.zero tp)
 
 let id tp = lambda tp (fun q -> q)
 let hadamard = lambda Pauli (fun q -> caseofP q pauliZ pauliX)
-let qft = lambda Pauli (fun q -> caseofP q pauliZ (pow pauliX (-1)))
+let qft = lambda Pauli (fun q -> caseofP q pauliZ (pow pauliX (const (-1))))
 let phasegate = lambda Pauli (fun q ->
     caseofP q
       (*X->*) pauliY
@@ -80,6 +80,10 @@ module Eval2 = LambdaPC.Eval(S2)
 open Interface
 
 
+(* Testing type relations *)
+module TypeChecker = Typing.SmtLambdaPC(S2)
+
+
 let evalTest () =
 
 
@@ -87,8 +91,8 @@ let evalTest () =
   eval (pauliY);
   eval pauliXY;
   eval (pauliNegX2Y3);
-  eval (pow pauliX 1);
-  eval (pow pauliZ 0);
+  eval (pow pauliX (const 1));
+  eval (pow pauliZ (const 0));
   eval (hadamard @ pauliX);
   eval (hadamard @ (phase (const 1) pauliZ));
   eval (pauliZ * pauliX);

--- a/lib/examples.ml
+++ b/lib/examples.ml
@@ -10,11 +10,11 @@ let pauliI : LambdaPC.Expr.t = pauli 0 0
 
 let pauliI_ tp = vec (LambdaC.HOAS.zero tp)
 
-let id tp = lambda tp (fun q -> var q)
-let hadamard = lambda Pauli (fun q -> caseofP (var q) pauliZ pauliX)
-let qft = lambda Pauli (fun q -> caseofP (var q) pauliZ (pow pauliX (-1)))
+let id tp = lambda tp (fun q -> q)
+let hadamard = lambda Pauli (fun q -> caseofP q pauliZ pauliX)
+let qft = lambda Pauli (fun q -> caseofP q pauliZ (pow pauliX (-1)))
 let phasegate = lambda Pauli (fun q ->
-    caseofP (var q)
+    caseofP q
       (*X->*) pauliY
       (*Z->*) pauliZ
   )
@@ -38,13 +38,13 @@ let rec in_n_i (n : int) (i : int) (t : LambdaPC.Expr.t) : LambdaPC.Expr.t =
   case t of {in_i q -> f i q}
 *)
 let rec match_in_i (n : int) (t : LambdaPC.Expr.t)
-                   (f : int -> LambdaPC.Variable.t -> LambdaPC.Expr.t)
+                   (f : int -> LambdaPC.Expr.t -> LambdaPC.Expr.t)
       : LambdaPC.Expr.t =
     assert (n > 0);
     let inc_f = fun j -> f (j + 1) in
     if n = 1
     then letin t (f 0)
-    else caseof t (fun q0 -> f 0 q0) (fun q' -> match_in_i (n-1) (var q') inc_f)
+    else caseof t (fun q0 -> f 0 q0) (fun q' -> match_in_i (n-1) q' inc_f)
 
 
 let ptensor tp1 tp2 t1 t2 =
@@ -56,18 +56,18 @@ let pauliNegX2Y3 = phase (const 1) (
 let pauliXY = in1 pauliX Pauli * in2 Pauli pauliY
 
 let swap tp1 tp2 = lambda (PTensor (tp1, tp2)) (fun q ->
-    caseof (var q)
-      (fun q1 -> in2 tp2 (var q1))
-      (fun q2 -> in1 (var q2) tp1)
+    caseof q
+      (fun q1 -> in2 tp2 q1)
+      (fun q2 -> in1 q2 tp1)
   )
 
 let cnot = lambda (PTensor (Pauli, Pauli)) (fun q ->
-    caseof (var q)
-      (fun q1 -> caseofP (var q1) 
+    caseof q
+      (fun q1 -> caseofP q1
                     (*Z->*) (in_n_i 2 0 pauliZ)
                     (*X->*) (in_n_i 2 0 pauliX * in_n_i 2 1 pauliX)
         )
-      (fun q2 -> caseofP (var q2)
+      (fun q2 -> caseofP q2
                     (*Z->*) (in1 pauliZ Pauli * in2 Pauli pauliZ)
                     (*X->*) (in2 Pauli pauliX)
         )

--- a/lib/examples.ml
+++ b/lib/examples.ml
@@ -73,6 +73,10 @@ let cnot = lambda (PTensor (Pauli, Pauli)) (fun q ->
         )
   )
 
+let bad_example = lambda Pauli (fun q ->
+  caseofP q pauliZ pauliZ
+  )
+
 (* Testing *)
 (*Scalars (Z FIN2)*)
 module S2 = Scalars.Scalars (Scalars.FIN2)

--- a/lib/interface.ml
+++ b/lib/interface.ml
@@ -3,14 +3,17 @@
 include LambdaPC.HOAS
 
 module S2 = Scalars.Scalars (Scalars.FIN2)
+module LEval2 = LambdaC.Eval(S2.Zd)
 module Eval2 = LambdaPC.Eval(S2)
 module Typing2 = Typing.SmtLambdaPC(S2)
 
 module S3 = Scalars.Scalars (Scalars.FIN3)
+module LEval3 = LambdaC.Eval(S3.Zd)
 module Eval3 = LambdaPC.Eval(S3)
 module Typing3 = Typing.SmtLambdaPC(S3)
 
 module S4 = Scalars.Scalars (Scalars.FIN4)
+module LEval4 = LambdaC.Eval(S4.Zd)
 module Eval4 = LambdaPC.Eval(S4)
 module Typing4 = Typing.SmtLambdaPC(S4)
 
@@ -42,6 +45,23 @@ let eval e =
   in
   let result = eval_closed e in
   print_endline (LambdaPC.Val.string_of_t result ^ "\n")
+
+
+let leval e =
+  print_endline (LambdaC.Expr.pretty_string_of_t e ^ "\n->*\n");
+  let eval_closed = match !dim with
+             | 2 -> LEval2.eval LambdaC.VariableMap.empty
+             | 3 -> LEval3.eval LambdaC.VariableMap.empty
+             | 4 -> LEval4.eval LambdaC.VariableMap.empty
+             | d -> failwith @@ "Please add evaluation module for dimension " ^ string_of_int d ^ "\n"
+  in
+  let result = eval_closed e in
+  print_endline (LambdaC.Val.string_of_t result ^ "\n")
+
+  
+
+let omega tp e1 e2 =
+  leval LambdaPC.SymplecticForm.(omega tp (psi_of e1) (psi_of e2))
 
 let typecheck pc =
   let typecheck_d = match !dim with

--- a/lib/interface.ml
+++ b/lib/interface.ml
@@ -3,6 +3,7 @@
 include LambdaPC.HOAS
 module S2 = Scalars.Scalars (Scalars.FIN2)
 module Eval2 = LambdaPC.Eval(S2)
+module Typing2 = Typing.SmtLambdaPC(S2)
 
 let parse (s : string) : LambdaPC.Expr.t =
   let lexbuf = Lexing.from_string s in
@@ -23,3 +24,7 @@ let eval e =
   print_endline (LambdaPC.Expr.pretty_string_of_t e ^ "\n->*\n");
   let result = Eval2.evalClosed e in
   print_endline (LambdaPC.Val.string_of_t result ^ "\n")
+
+let typecheck pc =
+  let (tp1,tp2) = Typing2.typecheck pc in
+  print_endline @@ LambdaPC.Expr.pretty_string_of_pc pc ^ " : |" ^ LambdaPC.Type.string_of_t tp1 ^ " -o " ^ LambdaPC.Type.string_of_t tp2 ^"|"

--- a/lib/interface.ml
+++ b/lib/interface.ml
@@ -1,9 +1,21 @@
 (* top-level interface for interacting with LambdaPC via the interpreter or other *)
 
 include LambdaPC.HOAS
+
 module S2 = Scalars.Scalars (Scalars.FIN2)
 module Eval2 = LambdaPC.Eval(S2)
 module Typing2 = Typing.SmtLambdaPC(S2)
+
+module S3 = Scalars.Scalars (Scalars.FIN3)
+module Eval3 = LambdaPC.Eval(S3)
+module Typing3 = Typing.SmtLambdaPC(S3)
+
+module S4 = Scalars.Scalars (Scalars.FIN4)
+module Eval4 = LambdaPC.Eval(S4)
+module Typing4 = Typing.SmtLambdaPC(S4)
+
+let dim = ref 2
+let set_dimension d = dim := d
 
 let parse (s : string) : LambdaPC.Expr.t =
   let lexbuf = Lexing.from_string s in
@@ -22,9 +34,21 @@ let parseFromFile (filename : string) : LambdaPC.Expr.t =
 
 let eval e =
   print_endline (LambdaPC.Expr.pretty_string_of_t e ^ "\n->*\n");
-  let result = Eval2.evalClosed e in
+  let eval_closed = match !dim with
+             | 2 -> Eval2.evalClosed
+             | 3 -> Eval3.evalClosed
+             | 4 -> Eval4.evalClosed
+             | d -> failwith @@ "Please add evaluation module for dimension " ^ string_of_int d ^ "\n"
+  in
+  let result = eval_closed e in
   print_endline (LambdaPC.Val.string_of_t result ^ "\n")
 
 let typecheck pc =
-  let (tp1,tp2) = Typing2.typecheck pc in
+  let typecheck_d = match !dim with
+             | 2 -> Typing2.typecheck
+             | 3 -> Typing3.typecheck
+             | 4 -> Typing4.typecheck
+             | d -> failwith @@ "Please add typing module to interface.ml for dimension " ^ string_of_int d ^ "\n"
+  in
+  let (tp1,tp2) = typecheck_d pc in
   print_endline @@ LambdaPC.Expr.pretty_string_of_pc pc ^ " : |" ^ LambdaPC.Type.string_of_t tp1 ^ " -o " ^ LambdaPC.Type.string_of_t tp2 ^"|"

--- a/lib/lambdaC.ml
+++ b/lib/lambdaC.ml
@@ -435,7 +435,7 @@ module TypeInformation = struct
     flush stdout;
     raise TypeError
   let debug _msg =
-    (*print_string _msg;*)
+    print_string _msg;
     ()
 
   let type_of_var (gamma : 'a VariableMap.t) (x : Variable.t) : 'a =

--- a/lib/lambdaC.ml
+++ b/lib/lambdaC.ml
@@ -435,7 +435,7 @@ module TypeInformation = struct
     flush stdout;
     raise TypeError
   let debug _msg =
-    print_string _msg;
+    (*print_string _msg;*)
     ()
 
   let type_of_var (gamma : 'a VariableMap.t) (x : Variable.t) : 'a =

--- a/lib/lambdaC.ml
+++ b/lib/lambdaC.ml
@@ -203,7 +203,9 @@ module HOAS = struct
   let set_variable_environment (env : VariableEnvironment.t) = var_env := env
   let fresh () : Variable.t = VariableEnvironment.fresh !var_env
 
-   let var x = Expr.Var x
+  let update_env (a : Expr.t) = Expr.update_env !var_env a
+
+  let var x = Expr.Var x
   let zero tp = Expr.Zero tp
   let (+) e1 e2 = Expr.Plus (e1,e2)
   let const x = Expr.Const x
@@ -211,13 +213,13 @@ module HOAS = struct
   let case e fx fz =
       let x = fresh() in
       let z = fresh() in
-      Expr.Case(e, x, fx x, z, fz z)
+      Expr.Case(e, x, fx (var x), z, fz (var z))
   
-  let lambda tp (f : Variable.t -> Expr.t) =
+  let lambda tp (f : Expr.t -> Expr.t) =
       let x = fresh() in
-      Expr.Lambda (x, tp, f x)
+      Expr.Lambda (x, tp, f (var x))
   let (@) e1 e2 = Expr.Apply (e1, e2)
-    
+
 end
 
 module Val = struct

--- a/lib/lambdaC.ml
+++ b/lib/lambdaC.ml
@@ -61,149 +61,149 @@ module Expr = struct
     | Lambda of Variable.t * Type.t * t
     | Apply of t * t
 
-    let rec string_of_t e =
-      match e with
+    let rec string_of_t a =
+      match a with
       | Var x -> "Var(" ^ string_of_int x ^ ")"
       | Let (a1,x,a2) -> "Let(" ^ string_of_t a1 ^ ", " ^ string_of_int x ^ ", " ^ string_of_t a2 ^ ")"
       | Zero tp -> "Zero(" ^ Type.string_of_t tp ^ ")"
-      | Annot (e, tp) -> "Annot( " ^ string_of_t e ^ ", " ^ Type.string_of_t tp ^ ")"
-      | Plus (e1, e2) -> "Plus(" ^ string_of_t e1 ^ ", " ^ string_of_t e2 ^ ")"
+      | Annot (a, tp) -> "Annot( " ^ string_of_t a ^ ", " ^ Type.string_of_t tp ^ ")"
+      | Plus (a1, a2) -> "Plus(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
       | Const c -> "Const(" ^ string_of_int c ^ ")"
-      | Scale (e1, e2) -> "Scale(" ^ string_of_t e1 ^ ", " ^ string_of_t e2 ^ ")"
-      | Pair (e1, e2) -> "Pair(" ^ string_of_t e1 ^ ", " ^ string_of_t e2 ^ ")"
-      | Case (scrut, x1, e1, x2, e2) ->
-          "Case(" ^ string_of_t scrut ^ ", " ^ string_of_int x1 ^ ", " ^ string_of_t e1 ^ ", " ^ string_of_int x2 ^ ", " ^ string_of_t e2 ^ ")"
+      | Scale (a1, a2) -> "Scale(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
+      | Pair (a1, a2) -> "Pair(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
+      | Case (scrut, x1, a1, x2, a2) ->
+          "Case(" ^ string_of_t scrut ^ ", " ^ string_of_int x1 ^ ", " ^ string_of_t a1 ^ ", " ^ string_of_int x2 ^ ", " ^ string_of_t a2 ^ ")"
       | Lambda (x, tp, body) ->
           "Lambda(" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ string_of_t body ^ ")"
-      | Apply (e1, e2) -> "Apply(" ^ string_of_t e1 ^ ", " ^ string_of_t e2 ^ ")"
+      | Apply (a1, a2) -> "Apply(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
 
     
-    let rec pretty_string_of_t e =
-      match e with
+    let rec pretty_string_of_t a =
+      match a with
       | Var x -> "x" ^ string_of_int x
       | Let (a1,x,a2) -> "let x" ^ string_of_int x ^ " = " ^ pretty_string_of_t a1 ^ " in " ^ pretty_string_of_t a2
       | Zero tp -> "0{" ^ Type.string_of_t tp ^ "}"
-      | Annot (e, tp) -> "(" ^ pretty_string_of_t e ^ " : " ^ Type.string_of_t tp ^ ")"
-      | Plus (e1, e2) -> pretty_string_of_t e1 ^ " + " ^ pretty_string_of_t e2
+      | Annot (a, tp) -> "(" ^ pretty_string_of_t a ^ " : " ^ Type.string_of_t tp ^ ")"
+      | Plus (a1, a2) -> pretty_string_of_t a1 ^ " + " ^ pretty_string_of_t a2
       | Const c -> string_of_int c
-      | Scale (e1, e2) -> pretty_string_of_t e1 ^ " * " ^ pretty_string_of_t e2
+      | Scale (a1, a2) -> pretty_string_of_t a1 ^ " * " ^ pretty_string_of_t a2
       | Pair (Const 0, Const 0) -> "I"
       | Pair (Const 1, Const 0) -> "X"
       | Pair (Const 0, Const 1) -> "Z"
       | Pair (Const 1, Const 1) -> "Y"
-      | Pair (e1, e2) -> "[" ^ pretty_string_of_t e1 ^ ", " ^ pretty_string_of_t e2 ^ "]"
-      | Case (scrut, x1, e1, x2, e2) ->
+      | Pair (a1, a2) -> "[" ^ pretty_string_of_t a1 ^ ", " ^ pretty_string_of_t a2 ^ "]"
+      | Case (scrut, x1, a1, x2, a2) ->
           "case " ^ pretty_string_of_t scrut
-          ^ " of { x" ^ string_of_int x1 ^ " -> " ^ pretty_string_of_t e1 
-          ^ " | x" ^ string_of_int x2 ^ " -> " ^ pretty_string_of_t e2 ^ "}"
+          ^ " of { x" ^ string_of_int x1 ^ " -> " ^ pretty_string_of_t a1 
+          ^ " | x" ^ string_of_int x2 ^ " -> " ^ pretty_string_of_t a2 ^ "}"
       | Lambda (x, tp, body) ->
           "lambda x" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ pretty_string_of_t body
-      | Apply (e1, e2) -> pretty_string_of_t e1 ^ " @ " ^ pretty_string_of_t e2
+      | Apply (a1, a2) -> pretty_string_of_t a1 ^ " @ " ^ pretty_string_of_t a2
 
 
-    let rec rename_var (from : Variable.t) (to_ : Variable.t) (e : t) : t =
-      match e with
+    let rec rename_var (from : Variable.t) (to_ : Variable.t) (a : t) : t =
+      match a with
       | Var x -> if x = from then Var to_ else Var x
       | Let (a1,x,a2) ->
         Let(rename_var from to_ a1,
             x,
             if x = from then a2 else rename_var from to_ a2)
       | Zero tp -> Zero tp
-      | Annot (e, tp) -> Annot(rename_var from to_ e, tp)
+      | Annot (a, tp) -> Annot(rename_var from to_ a, tp)
       | Const c -> Const c
-      | Plus (e1, e2) -> Plus (rename_var from to_ e1, rename_var from to_ e2)
-      | Scale (e1, e2) -> Scale (rename_var from to_ e1, rename_var from to_ e2)
-      | Pair (e1, e2) -> Pair (rename_var from to_ e1, rename_var from to_ e2)
-      | Case (scrut, x1, e1, x2, e2) ->
-          let e1' = if x1 = from then e1 else rename_var from to_ e1 in
-          let e2' = if x2 = from then e2 else rename_var from to_ e2 in
-          Case (rename_var from to_ scrut, x1, e1', x2, e2')
+      | Plus (a1, a2) -> Plus (rename_var from to_ a1, rename_var from to_ a2)
+      | Scale (a1, a2) -> Scale (rename_var from to_ a1, rename_var from to_ a2)
+      | Pair (a1, a2) -> Pair (rename_var from to_ a1, rename_var from to_ a2)
+      | Case (scrut, x1, a1, x2, a2) ->
+          let a1' = if x1 = from then a1 else rename_var from to_ a1 in
+          let a2' = if x2 = from then a2 else rename_var from to_ a2 in
+          Case (rename_var from to_ scrut, x1, a1', x2, a2')
       | Lambda (x, tp, body) ->
           if x = from then Lambda (x, tp, body)
           else Lambda (x, tp, rename_var from to_ body)
-      | Apply (e1, e2) -> Apply (rename_var from to_ e1, rename_var from to_ e2)
+      | Apply (a1, a2) -> Apply (rename_var from to_ a1, rename_var from to_ a2)
 
-    (* Apply the function f to all constants in e *)
-    let rec map (f : int -> int) (e : t) : t =
-      match e with
+    (* Apply the function f to all constants in a *)
+    let rec map (f : int -> int) (a : t) : t =
+      match a with
       | Var x -> Var x
       | Let(a1,x,a2) -> Let (map f a1, x, map f a2)
       | Zero tp -> Zero tp
-      | Annot (e', tp) -> Annot(map f e', tp)
-      | Plus (e1, e2) ->
-        Plus (map f e1, map f e2)
+      | Annot (a', tp) -> Annot(map f a', tp)
+      | Plus (a1, a2) ->
+        Plus (map f a1, map f a2)
       | Const c -> Const (f c)
-      | Scale (e1, e2) ->
-        Scale (map f e1, map f e2)
-      | Pair (e1, e2) ->
-        Pair (map f e1, map f e2)
-      | Case (e0, x1, e1, x2, e2) ->
-        Case (map f e0, x1, map f e1, x2, map f e2)
-      | Lambda (x, tp, e') ->
-        Lambda (x, tp, map f e')
-      | Apply (e1,e2) -> 
-        Apply (map f e1, map f e2)
+      | Scale (a1, a2) ->
+        Scale (map f a1, map f a2)
+      | Pair (a1, a2) ->
+        Pair (map f a1, map f a2)
+      | Case (a0, x1, a1, x2, a2) ->
+        Case (map f a0, x1, map f a1, x2, map f a2)
+      | Lambda (x, tp, a') ->
+        Lambda (x, tp, map f a')
+      | Apply (a1,a2) -> 
+        Apply (map f a1, map f a2)
 
-    (* Update env so its next fresh variable is not in e *)
-    let rec update_env env e =
-      match e with
+    (* Update env so its next fresh variable is not in a *)
+    let rec update_env env a =
+      match a with
       | Var x -> VariableEnvironment.update x env
       | Let(a1,x,a2) ->
         update_env env a1;
         VariableEnvironment.update x env;
         update_env env a2
       | Zero _ -> ()
-      | Annot (e', _) -> update_env env e'
-      | Plus (e1, e2) -> update_env env e1; update_env env e2
+      | Annot (a', _) -> update_env env a'
+      | Plus (a1, a2) -> update_env env a1; update_env env a2
       | Const _ -> ()
-      | Scale (e1, e2) -> update_env env e1; update_env env e2
-      | Pair (e1, e2) -> update_env env e1; update_env env e2
-      | Case (e', x1, e1', x2, e2') ->
-        update_env env e';
+      | Scale (a1, a2) -> update_env env a1; update_env env a2
+      | Pair (a1, a2) -> update_env env a1; update_env env a2
+      | Case (a', x1, a1', x2, a2') ->
+        update_env env a';
         VariableEnvironment.update x1 env;
         VariableEnvironment.update x2 env;
-        update_env env e1';
-        update_env env e2'
-      | Lambda (x,_,e') ->
+        update_env env a1';
+        update_env env a2'
+      | Lambda (x,_,a') ->
         VariableEnvironment.update x env;
-        update_env env e'
-      | Apply (e1, e2) -> update_env env e1; update_env env e2
+        update_env env a'
+      | Apply (a1, a2) -> update_env env a1; update_env env a2
 
     (* alpha equivalence *)
-    (* Take as input two expressions. Returns true iff they are syntactically equal (including free variables, possibly not including type or usage annotations) up to renaming their bound variables. To check if two binders are equal e.g. (lambda x1.e1) and (lambda x2.e2), the function will create a fresh variable y from env and rename both x1 and x2 to y.
-      Requires: fresh env will always return a variable that does not occur in either e1 or e2
+    (* Take as input two expressions. Returns true iff they are syntactically equal (including free variables, possibly not including type or usage annotations) up to renaming their bound variables. To check if two binders are equal e.g. (lambda x1.a1) and (lambda x2.a2), the function will create a fresh variable y from env and rename both x1 and x2 to y.
+      Requires: fresh env will always return a variable that does not occur in either a1 or a2
     *)
-    let rec alpha_equiv' (env : VariableEnvironment.t) e1 e2 =
-      match e1, e2 with
+    let rec alpha_equiv' (env : VariableEnvironment.t) a1 a2 =
+      match a1, a2 with
       | Var x1, Var x2 -> x1 = x2
       | Let(a1,x1,a1'), Let(a2,x2,a2') ->
         let x = VariableEnvironment.fresh env in
         alpha_equiv' env a1 a2
           && alpha_equiv' env (rename_var x1 x a1') (rename_var x2 x a2')
       | Zero tp1, Zero tp2 -> tp1 = tp2
-      | Annot(e1', tp1), Annot(e2', tp2) -> tp1 = tp2 && alpha_equiv' env e1' e2'
-      | Annot(e1', _), _ -> alpha_equiv' env e1' e2
-      | _, Annot(e2', _) -> alpha_equiv' env e1 e2'
-      | Plus (e11,e12), Plus(e21,e22) -> alpha_equiv' env e11 e21 && alpha_equiv' env e12 e22
+      | Annot(a1', tp1), Annot(a2', tp2) -> tp1 = tp2 && alpha_equiv' env a1' a2'
+      | Annot(a1', _), _ -> alpha_equiv' env a1' a2
+      | _, Annot(a2', _) -> alpha_equiv' env a1 a2'
+      | Plus (a11,a12), Plus(a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
       | Const v1, Const v2 -> v1 = v2
-      | Scale (e11,e12), Scale (e21,e22) -> alpha_equiv' env e11 e21 && alpha_equiv' env e12 e22
-      | Pair (e11,e12), Pair (e21,e22) -> alpha_equiv' env e11 e21 && alpha_equiv' env e12 e22
-      | Case (e1',x11,e11,x12,e12), Case(e2',x21,e21,x22,e22) ->
+      | Scale (a11,a12), Scale (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
+      | Pair (a11,a12), Pair (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
+      | Case (a1',x11,a11,x12,a12), Case(a2',x21,a21,x22,a22) ->
         let x = VariableEnvironment.fresh env in
-        alpha_equiv' env e1' e2'
-        && alpha_equiv' env (rename_var x11 x e11) (rename_var x21 x e21)
-        && alpha_equiv' env (rename_var x12 x e12) (rename_var x22 x e22)
-      | Lambda (x1, tp1, e1), Lambda (x2, tp2, e2) ->
+        alpha_equiv' env a1' a2'
+        && alpha_equiv' env (rename_var x11 x a11) (rename_var x21 x a21)
+        && alpha_equiv' env (rename_var x12 x a12) (rename_var x22 x a22)
+      | Lambda (x1, tp1, a1), Lambda (x2, tp2, a2) ->
         let x = VariableEnvironment.fresh env in
-        tp1 = tp2 && alpha_equiv' env (rename_var x1 x e1) (rename_var x2 x e2)
-      | Apply (e11,e12), Apply (e21,e22) -> alpha_equiv' env e11 e21 && alpha_equiv' env e12 e22
+        tp1 = tp2 && alpha_equiv' env (rename_var x1 x a1) (rename_var x2 x a2)
+      | Apply (a11,a12), Apply (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
       | _, _ -> false
 
-    let alpha_equiv e1 e2 =
+    let alpha_equiv a1 a2 =
       let env = VariableEnvironment.init in
-      update_env env e1;
-      update_env env e2;
-      alpha_equiv' env e1 e2
+      update_env env a1;
+      update_env env a2;
+      alpha_equiv' env a1 a2
 
   end
 
@@ -216,20 +216,20 @@ module HOAS = struct
 
   let var x = Expr.Var x
   let zero tp = Expr.Zero tp
-  let (+) e1 e2 = Expr.Plus (e1,e2)
+  let (+) a1 a2 = Expr.Plus (a1,a2)
   let const x = Expr.Const x
-  let ( * ) e1 e2 = Expr.Scale (e1,e2)
-  let case e fx fz =
+  let ( * ) a1 a2 = Expr.Scale (a1,a2)
+  let case a fx fz =
       let x = fresh() in
       let z = fresh() in
-      Expr.Case(e, x, fx (var x), z, fz (var z))
+      Expr.Case(a, x, fx (var x), z, fz (var z))
   
   let lambda tp (f : Expr.t -> Expr.t) =
       let x = fresh() in
       Expr.Lambda (x, tp, f (var x))
 
-  let (@) e1 e2 = Expr.Apply (e1, e2)
-  let pair e1 e2 = Expr.Pair (e1,e2)
+  let (@) a1 a2 = Expr.Apply (a1, a2)
+  let pair a1 a2 = Expr.Pair (a1,a2)
 
 end
 
@@ -244,8 +244,8 @@ module Val = struct
           match v with
           | Const c -> string_of_int c
           | Pair (v1, v2) -> "(" ^ string_of_t v1 ^ ", " ^ string_of_t v2 ^ ")"
-          | Lambda (x, tp, e) ->
-              "Lambda(" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.string_of_t e ^ ")"
+          | Lambda (x, tp, a) ->
+              "Lambda(" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.string_of_t a ^ ")"
 
 
     let rec pretty_string_of_t v =
@@ -256,21 +256,21 @@ module Val = struct
           | Pair (Const 0, Const 1) -> "Z"
           | Pair (Const 1, Const 1) -> "Y"
           | Pair (v1, v2) -> "(" ^ pretty_string_of_t v1 ^ ", " ^ pretty_string_of_t v2 ^ ")"
-          | Lambda (x, tp, e) ->
-              "lambda x" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.pretty_string_of_t e
+          | Lambda (x, tp, a) ->
+              "lambda x" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.pretty_string_of_t a
 
     let rec expr_of_t v =
       match v with
       | Const c -> Expr.Const c
       | Pair (v1, v2) -> Expr.Pair (expr_of_t v1, expr_of_t v2)
-      | Lambda (x, tp, e) -> Expr.Lambda (x, tp, e)
+      | Lambda (x, tp, a) -> Expr.Lambda (x, tp, a)
 
 
     let rec map (f : int -> int) (v : t) : t =
         match v with
         | Const r -> Const (f r)
         | Pair (v1, v2) -> Pair (map f v1, map f v2)
-        | Lambda (x,tp,e) -> Lambda (x,tp, Expr.map f e)
+        | Lambda (x,tp,a) -> Lambda (x,tp, Expr.map f a)
 
     let alpha_equiv v1 v2 = Expr.alpha_equiv (expr_of_t v1) (expr_of_t v2)
 
@@ -299,12 +299,12 @@ module Eval (Zd : Z_SIG) = struct
     | Val.Const c1, Val.Const c2 -> Val.Const (Zd.normalize(c1 + c2))
     | Val.Pair (a1, b1), Val.Pair (a2, b2) ->
       Val.Pair (vplus a1 a2, vplus b1 b2)
-    | Val.Lambda (x1, tp1, e1), Val.Lambda (x2, tp2, e2) ->
+    | Val.Lambda (x1, tp1, a1), Val.Lambda (x2, tp2, a2) ->
         if tp1 = tp2 then
             let fresh_x = fresh() in
-            let e1' = Expr.rename_var x1 fresh_x e1 in
-            let e2' = Expr.rename_var x2 fresh_x e2 in
-            Val.Lambda (fresh_x, tp1, Expr.Plus (e1', e2'))
+            let a1' = Expr.rename_var x1 fresh_x a1 in
+            let a2' = Expr.rename_var x2 fresh_x a2 in
+            Val.Lambda (fresh_x, tp1, Expr.Plus (a1', a2'))
         else
             failwith "vplus: Lambda types do not match"
     | _, _ -> failwith "vplus: mismatched values"
@@ -313,36 +313,36 @@ module Eval (Zd : Z_SIG) = struct
     match v2 with
     | Val.Const c -> Val.Const (v1 * c)
     | Val.Pair (a, b) -> Val.Pair (vscale v1 a, vscale v1 b)
-    | Val.Lambda (x, tp, e) -> Val.Lambda (x, tp, Scale (Const v1, e))
+    | Val.Lambda (x, tp, a) -> Val.Lambda (x, tp, Scale (Const v1, a))
 
-  let rec eval (ctx : Val.t VariableMap.t) (e : Expr.t) : Val.t =
-    match e with
+  let rec eval (ctx : Val.t VariableMap.t) (a : Expr.t) : Val.t =
+    match a with
     | Var x -> (try VariableMap.find x ctx with Not_found -> failwith "Unbound variable")
     | Let(a1,x,a2) ->
       let v = eval ctx a1 in
       let ctx' = VariableMap.add x v ctx in
       eval ctx' a2
     | Zero tp -> vzero tp
-    | Annot (e', _) -> eval ctx e'
+    | Annot (a', _) -> eval ctx a'
     | Const c -> Val.Const (Zd.normalize c)
-    | Plus (e1, e2) -> vplus (eval ctx e1) (eval ctx e2)
-    | Scale (e1, e2) ->
-        (match eval ctx e1 with
-        | Val.Const c -> vscale c (eval ctx e2)
+    | Plus (a1, a2) -> vplus (eval ctx a1) (eval ctx a2)
+    | Scale (a1, a2) ->
+        (match eval ctx a1 with
+        | Val.Const c -> vscale c (eval ctx a2)
         | _ -> failwith "Scale: first argument must be a scalar")
-    | Pair (e1, e2) -> Val.Pair (eval ctx e1, eval ctx e2)
-    | Case (scrut, x1, e1, x2, e2) ->
+    | Pair (a1, a2) -> Val.Pair (eval ctx a1, eval ctx a2)
+    | Case (scrut, x1, a1, x2, a2) ->
         (match eval ctx scrut with
         | Val.Pair (v1, v2) ->
             let ctx1 = VariableMap.add x1 v1 ctx in
             let ctx2 = VariableMap.add x2 v2 ctx in
-            vplus (eval ctx1 e1) (eval ctx2 e2)
+            vplus (eval ctx1 a1) (eval ctx2 a2)
         | _ -> failwith "Case: scrutinee must be a pair")
     | Lambda (x, tp, body) -> Val.Lambda (x, tp, body)
-    | Apply (e1, e2) ->
-        (match eval ctx e1 with
+    | Apply (a1, a2) ->
+        (match eval ctx a1 with
         | Val.Lambda (x, _tp, body) ->
-            let arg = eval ctx e2 in
+            let arg = eval ctx a2 in
             let ctx' = VariableMap.add x arg ctx in
             eval ctx' body
         | _ -> failwith "Apply: not a lambda")
@@ -408,132 +408,132 @@ module Typing = struct
     else terr @@ "Expected usage context " ^ UsageContext.string_of_t u1
                ^ "\nto be a subset of " ^ UsageContext.string_of_t u2
 
-  let check_var gamma u x (tau0 : Type.t option) (u0 : usage_context option) =
-    let tau' = type_of_var gamma x in
+  let check_var gamma u x (alpha0 : Type.t option) (u0 : usage_context option) =
+    let alpha' = type_of_var gamma x in
     let u' = UsageContext.remove x u in
     assert_available x u true;
-    assert_type tau0 tau';
+    assert_type alpha0 alpha';
     assert_usage u0 u';
-    (tau',u')
+    (alpha',u')
 
-  let check_sum (tau0 : Type.t option) : (Type.t option) * (Type.t option) =
-    match tau0 with
+  let check_sum (alpha0 : Type.t option) : (Type.t option) * (Type.t option) =
+    match alpha0 with
     | None -> (None, None)
-    | Some (Type.Sum (tau1, tau2)) -> (Some tau1, Some tau2)
-    | Some tau -> terr @@ "Expected a sum type, received: " ^ Type.string_of_t tau
-  let check_arrow (tau0 : Type.t option) : (Type.t option) * (Type.t option) =
-    match tau0 with
+    | Some (Type.Sum (alpha1, alpha2)) -> (Some alpha1, Some alpha2)
+    | Some alpha -> terr @@ "Expected a sum type, received: " ^ Type.string_of_t alpha
+  let check_arrow (alpha0 : Type.t option) : (Type.t option) * (Type.t option) =
+    match alpha0 with
     | None -> (None, None)
-    | Some (Type.Arrow (tau1, tau2)) -> (Some tau1, Some tau2)
-    | Some tau -> terr @@ "Expected an arrow type, received: " ^ Type.string_of_t tau
+    | Some (Type.Arrow (alpha1, alpha2)) -> (Some alpha1, Some alpha2)
+    | Some alpha -> terr @@ "Expected an arrow type, received: " ^ Type.string_of_t alpha
 
-  let rec typecheck0 gamma u e tau0 u0 =
-    match e with
-    | Expr.Var x -> check_var gamma u x tau0 u0
-    | Annot (e',tau) ->
-      assert_type tau0 tau;
-      typecheck0 gamma u e' (Some tau) u0
-    | Zero tau ->
-      assert_type tau0 tau;
+  let rec typecheck0 gamma u a alpha0 u0 =
+    match a with
+    | Expr.Var x -> check_var gamma u x alpha0 u0
+    | Annot (a',alpha) ->
+      assert_type alpha0 alpha;
+      typecheck0 gamma u a' (Some alpha) u0
+    | Zero alpha ->
+      assert_type alpha0 alpha;
       (match u0 with
-      | Some u' -> (tau, u')
+      | Some u' -> (alpha, u')
       | None -> raise InferenceError
       )
-    | ZeroA (tau, u') ->
-      assert_type tau0 tau;
+    | ZeroA (alpha, u') ->
+      assert_type alpha0 alpha;
       assert_usage u0 u';
       assert_usage_subset u' u;
-      (tau, u')
+      (alpha, u')
 
     | Const _ ->
-      assert_type tau0 Type.Unit;
+      assert_type alpha0 Type.Unit;
       assert_usage u0 u;
       (Type.Unit, u)
 
 
-    | Scale (e1, e2) -> (
+    | Scale (a1, a2) -> (
       try
-        let (_, u') = typecheck0 gamma u e1 (Some Type.Unit) None in
-        typecheck0 gamma u' e2 tau0 u0
+        let (_, u') = typecheck0 gamma u a1 (Some Type.Unit) None in
+        typecheck0 gamma u' a2 alpha0 u0
       with
       | InferenceError ->
-        let (tau', u') = typecheck0 gamma u e2 tau0 None in
-        let (_, u'') = typecheck0 gamma u' e1 (Some Type.Unit) u0 in
-        (tau', u'')
+        let (alpha', u') = typecheck0 gamma u a2 alpha0 None in
+        let (_, u'') = typecheck0 gamma u' a1 (Some Type.Unit) u0 in
+        (alpha', u'')
     )
 
-    | Plus (e1, e2) -> (
+    | Plus (a1, a2) -> (
       try
-        let (tau,u') = typecheck0 gamma u e1 tau0 u0 in
-        typecheck0 gamma u' e2 (Some tau) (Some u')
+        let (alpha,u') = typecheck0 gamma u a1 alpha0 u0 in
+        typecheck0 gamma u' a2 (Some alpha) (Some u')
       with
       | InferenceError ->
-        let (tau,u') = typecheck0 gamma u e2 tau0 u0 in
-        typecheck0 gamma u' e1 (Some tau) (Some u')
+        let (alpha,u') = typecheck0 gamma u a2 alpha0 u0 in
+        typecheck0 gamma u' a1 (Some alpha) (Some u')
       )
 
-    | Pair (e1, e2) ->
-      let (tau10, tau20) = check_sum tau0 in
+    | Pair (a1, a2) ->
+      let (alpha10, alpha20) = check_sum alpha0 in
       (try
-        let (tau1, u') = typecheck0 gamma u e1 tau10 u0 in
-        let (tau2, _) = typecheck0 gamma u e2 tau20 (Some u') in
-        (Type.Sum (tau1,tau2), u')
+        let (alpha1, u') = typecheck0 gamma u a1 alpha10 u0 in
+        let (alpha2, _) = typecheck0 gamma u a2 alpha20 (Some u') in
+        (Type.Sum (alpha1,alpha2), u')
       with
       | InferenceError ->
-        let (tau2, u') = typecheck0 gamma u e2 tau20 u0 in
-        let (tau1, _) = typecheck0 gamma u e1 tau10 (Some u') in
-        (Type.Sum (tau1,tau2), u') 
+        let (alpha2, u') = typecheck0 gamma u a2 alpha20 u0 in
+        let (alpha1, _) = typecheck0 gamma u a1 alpha10 (Some u') in
+        (Type.Sum (alpha1,alpha2), u') 
       )
 
     | Case (a, x1, a1, x2, a2) ->
-      let (tau, u') = typecheck0 gamma u a None None in
-      let (Some tau1, Some tau2) = check_sum (Some tau) [@@warning "-partial-match"] in
-      let gamma1 = VariableMap.add x1 tau1 gamma in
-      let gamma2 = VariableMap.add x2 tau2 gamma in
+      let (alpha, u') = typecheck0 gamma u a None None in
+      let (Some alpha1, Some alpha2) = check_sum (Some alpha) [@@warning "-partial-match"] in
+      let gamma1 = VariableMap.add x1 alpha1 gamma in
+      let gamma2 = VariableMap.add x2 alpha2 gamma in
       let u1 = UsageContext.add x1 u' in
       let u2 = UsageContext.add x2 u' in
       
-      let (tau',u'') =
+      let (alpha',u'') =
         (try
-          let (tau', u'') = typecheck0 gamma1 u1 a1 tau0 u0 in
-          typecheck0 gamma2 u2 a2 (Some tau') (Some u'')
+          let (alpha', u'') = typecheck0 gamma1 u1 a1 alpha0 u0 in
+          typecheck0 gamma2 u2 a2 (Some alpha') (Some u'')
         with
         | InferenceError ->
-          let (tau', u'') = typecheck0 gamma2 u2 a2 tau0 u0 in
-          typecheck0 gamma1 u1 a1 (Some tau') (Some u'')
+          let (alpha', u'') = typecheck0 gamma2 u2 a2 alpha0 u0 in
+          typecheck0 gamma1 u1 a1 (Some alpha') (Some u'')
         ) in
 
       assert_available x1 u'' false;
       assert_available x2 u'' false;
-      (tau', u'')
+      (alpha', u'')
 
-    | Lambda (x, tau1, e') ->
-      let (tau10, tau20) = check_arrow tau0 in
-      assert_type tau10 tau1;
-      let gamma' = VariableMap.add x tau1 gamma in
+    | Lambda (x, alpha1, a') ->
+      let (alpha10, alpha20) = check_arrow alpha0 in
+      assert_type alpha10 alpha1;
+      let gamma' = VariableMap.add x alpha1 gamma in
       let u' = UsageContext.add x u in
-      let (tau2, u'') = typecheck0 gamma' u' e' tau20 u0 in
+      let (alpha2, u'') = typecheck0 gamma' u' a' alpha20 u0 in
       assert_available x u'' false;
-      (Type.Arrow (tau1, tau2), u'')
+      (Type.Arrow (alpha1, alpha2), u'')
 
-    | Apply (e1, e2) -> (
+    | Apply (a1, a2) -> (
       try
-        let (tau, u') = typecheck0 gamma u e1 None None in
-        let (Some tau1, Some tau2) = check_arrow (Some tau) [@@warning "-partial-match"] in
-        let (_, u'') = typecheck0 gamma u' e2 (Some tau1) u0 in
-        (Type.Arrow(tau1, tau2), u'')
+        let (alpha, u') = typecheck0 gamma u a1 None None in
+        let (Some alpha1, Some alpha2) = check_arrow (Some alpha) [@@warning "-partial-match"] in
+        let (_, u'') = typecheck0 gamma u' a2 (Some alpha1) u0 in
+        (Type.Arrow(alpha1, alpha2), u'')
       with
       | InferenceError ->
-        let (tau1, u') = typecheck0 gamma u e2 None None in
-        let tau0' = Option.map (fun tau2 -> Type.Arrow(tau1,tau2)) tau0 in
-        let (tau', u'') = typecheck0 gamma u' e1 tau0' u0 in
-        let (Some tau1, Some tau2) = check_arrow (Some tau') [@@warning "-partial-match"] in
-        (Type.Arrow (tau1, tau2), u'')
+        let (alpha1, u') = typecheck0 gamma u a2 None None in
+        let alpha0' = Option.map (fun alpha2 -> Type.Arrow(alpha1,alpha2)) alpha0 in
+        let (alpha', u'') = typecheck0 gamma u' a1 alpha0' u0 in
+        let (Some alpha1, Some alpha2) = check_arrow (Some alpha') [@@warning "-partial-match"] in
+        (Type.Arrow (alpha1, alpha2), u'')
     )
 
-  let typecheck e = 
-    let (tau,u) = typecheck0 VariableMap.empty UsageContext.empty e None None in
-    if UsageContext.is_empty(u) then tau
+  let typecheck a = 
+    let (alpha,u) = typecheck0 VariableMap.empty UsageContext.empty a None None in
+    if UsageContext.is_empty(u) then alpha
     else 
       let msg = "Unused variables: " ^ UsageContext.string_of_t u in
       raise (TypeError msg)

--- a/lib/lambdaC.ml
+++ b/lib/lambdaC.ml
@@ -218,6 +218,7 @@ module HOAS = struct
   let lambda tp (f : Expr.t -> Expr.t) =
       let x = fresh() in
       Expr.Lambda (x, tp, f (var x))
+
   let (@) e1 e2 = Expr.Apply (e1, e2)
 
 end

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -20,8 +20,8 @@ end
 module Expr : sig
   type t =
       Var of Variable.t
+    | Let of t * Variable.t * t
     | Zero of Type.t
-    | ZeroA of Type.t * UsageContext.t
     | Annot of t * Type.t
     | Plus of t * t
     | Const of int
@@ -55,6 +55,7 @@ module HOAS : sig
   val case : Expr.t -> (Expr.t -> Expr.t) -> (Expr.t -> Expr.t) -> Expr.t
   val lambda : Type.t -> (Expr.t -> Expr.t) -> Expr.t
   val (@) : Expr.t -> Expr.t -> Expr.t
+  val pair : Expr.t -> Expr.t -> Expr.t
 
 
   (* Helper functions for performing the symplectic form *)
@@ -86,6 +87,8 @@ module Eval : functor (Zd : Z_SIG) -> sig
 
 end
 
+(*
+
 module Typing : sig
   type typing_context
   type usage_context
@@ -93,7 +96,7 @@ module Typing : sig
   exception InferenceError
   val typecheck : Expr.t -> Type.t
 end
-
+*)
 
 (* module Expr_Functor (A : Z_SIG) (B : Z_SIG) : sig
   val map_expr : (A.t -> B.t) -> Expr.t -> Expr.t

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -36,6 +36,7 @@ module Expr : sig
 
   val string_of_t : t -> string
   val pretty_string_of_t : t -> string
+  val subst : Variable.t -> t -> t -> t
   val rename_var : Variable.t -> Variable.t -> t -> t
   val map : (int -> int) -> t -> t
   val update_env : VariableEnvironment.t -> t -> unit
@@ -104,6 +105,7 @@ module TypeInformation : sig
 
   exception TypeError
   val terr : string -> 'a
+  val debug : string -> unit
   val type_of_var : 'a VariableMap.t -> Variable.t -> 'a
   val assert_type : ('a -> string) -> 'a -> 'a -> unit
 

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -7,7 +7,7 @@ end
 
 module Variable : Map.OrderedType with type t = int
 module VariableMap : Map.S with type key = Variable.t
-module UsageContext : Set.S
+module UsageContext : Set.S with type elt = Variable.t
 
 
 module VariableEnvironment : sig
@@ -87,16 +87,20 @@ module Eval : functor (Zd : Z_SIG) -> sig
 
 end
 
-(*
 
 module Typing : sig
   type typing_context
-  type usage_context
+  type usage_relation = UsageContext.t -> UsageContext.t -> bool
+
+  type type_information = {
+    usage : usage_relation;
+    expr : Expr.t;
+    tp : Type.t;
+  }
   exception TypeError of string
-  exception InferenceError
-  val typecheck : Expr.t -> Type.t
+  val typecheck : typing_context -> Expr.t -> type_information
 end
-*)
+
 
 (* module Expr_Functor (A : Z_SIG) (B : Z_SIG) : sig
   val map_expr : (A.t -> B.t) -> Expr.t -> Expr.t

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -118,6 +118,8 @@ end
 module Typing : sig
   val string_of_info : (Type.t,Expr.t) TypeInformation.t -> string
   val pp_info : (Type.t,Expr.t) TypeInformation.t -> unit
+  val assert_arrow_type : Type.t -> Type.t * Type.t
+  val assert_sum_type : Type.t -> Type.t * Type.t
   val typecheck' : Type.t VariableMap.t -> Expr.t -> (Type.t,Expr.t) TypeInformation.t
   val typecheck : Expr.t -> (Type.t,Expr.t) TypeInformation.t
 end

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -7,6 +7,7 @@ end
 
 module Variable : Map.OrderedType with type t = int
 module VariableMap : Map.S with type key = Variable.t
+module UsageContext : Set.S
 
 
 module VariableEnvironment : sig
@@ -20,6 +21,8 @@ module Expr : sig
   type t =
       Var of Variable.t
     | Zero of Type.t
+    | ZeroA of Type.t * UsageContext.t
+    | Annot of t * Type.t
     | Plus of t * t
     | Const of int
     | Scale of t * t
@@ -80,9 +83,11 @@ module Eval : functor (Zd : Z_SIG) -> sig
 end
 
 module Typing : sig
-  type typing_context = Type.t VariableMap.t
+  type typing_context
+  type usage_context
   exception TypeError of string
-  val type_of : typing_context -> Expr.t -> Type.t
+  exception InferenceError
+  val typecheck : Expr.t -> Type.t
 end
 
 

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -97,12 +97,9 @@ module Typing : sig
     expr : Expr.t;
     tp : Type.t;
   }
-  exception TypeError of string
-  val typecheck : typing_context -> Expr.t -> type_information
+  val string_of_info : type_information -> string
+  val pp_info : type_information -> unit
+  exception TypeError
+  val typecheck' : typing_context -> Expr.t -> type_information
+  val typecheck : Expr.t -> type_information
 end
-
-
-(* module Expr_Functor (A : Z_SIG) (B : Z_SIG) : sig
-  val map_expr : (A.t -> B.t) -> Expr.t -> Expr.t
-  val map_lval : (A.t -> B.t) -> Val.t -> Val.t
-end *)

--- a/lib/lambdaC.mli
+++ b/lib/lambdaC.mli
@@ -45,15 +45,19 @@ module HOAS : sig
   val var_env : VariableEnvironment.t ref
   val set_variable_environment : VariableEnvironment.t -> unit
   val fresh : unit -> Variable.t
+  val update_env : Expr.t -> unit
 
   val var : Variable.t -> Expr.t
   val zero : Type.t -> Expr.t
   val (+) : Expr.t -> Expr.t -> Expr.t
   val const : int -> Expr.t
   val ( * ) : Expr.t -> Expr.t -> Expr.t
-  val case : Expr.t -> (Variable.t -> Expr.t) -> (Variable.t -> Expr.t) -> Expr.t
-  val lambda : Type.t -> (Variable.t -> Expr.t) -> Expr.t
-  val (@) : Expr.t -> Expr.t -> Expr.t    
+  val case : Expr.t -> (Expr.t -> Expr.t) -> (Expr.t -> Expr.t) -> Expr.t
+  val lambda : Type.t -> (Expr.t -> Expr.t) -> Expr.t
+  val (@) : Expr.t -> Expr.t -> Expr.t
+
+
+  (* Helper functions for performing the symplectic form *)
 end
 
 module Val : sig

--- a/lib/lambdaPC.ml
+++ b/lib/lambdaPC.ml
@@ -85,7 +85,6 @@ let rec pretty_string_of_t e =
         "(" ^ pretty_string_of_t e' ^ " : " ^ Type.string_of_t tau' ^ ")"
       | Let (e1, x, e2) -> "let " ^ string_of_int x ^ " = " ^ pretty_string_of_t e1 ^ " in " ^ pretty_string_of_t e2
       | LExpr le ->
-        "Delta" ^
         LambdaC.Expr.pretty_string_of_t le
       | Phase (a, t) -> "<" ^ LambdaC.Expr.pretty_string_of_t a ^ "> " ^ pretty_string_of_t t
       | Prod (t1, t2) -> "(" ^ pretty_string_of_t t1 ^ ") * (" ^ pretty_string_of_t t2 ^ ")"
@@ -220,7 +219,7 @@ module SymplecticForm = struct
     ccaseP a1
       (ccaseP a2 
         (*t1=[1,0],t2=[1,0]*) (const 0)
-        (*t1=[1,0],t2=[0,1]*) (const 1)
+        (*t1=[1,0],t2=[0,1]*) (const (-1))
       )
       (ccaseP a2 
         (*t1=[0,1],t2=[1,0]*) (const 1)
@@ -385,4 +384,5 @@ module Eval (S : SCALARS) = struct
     | Force (Suspend e') -> eval (VariableMap.empty) e'
 
   let evalClosed e = eval VariableMap.empty e
+
 end

--- a/lib/lambdaPC.ml
+++ b/lib/lambdaPC.ml
@@ -191,8 +191,11 @@ module SymplecticForm = struct
       LambdaC.Expr.Case(psi_of t',
         x1, psi_of t1,
         x2, psi_of t2)
-    | Apply (Lam(x,tp,t1),t2) -> LambdaC.Expr.Lambda(x, Type.ltype_of_t tp,psi_of t1) @ psi_of t2
+    | Apply (pc1,t2) -> psi_of_pc pc1 @ psi_of t2
     | Force (Suspend t') -> psi_of t'
+  and psi_of_pc pc =
+    let (Lam(x,tp,t)) = pc in
+    LambdaC.Expr.Lambda(x,Type.ltype_of_t tp, psi_of t)
 
   let omega1 a1 a2 =
     ccaseP a1

--- a/lib/lambdaPC.ml
+++ b/lib/lambdaPC.ml
@@ -84,7 +84,9 @@ let rec pretty_string_of_t e =
       | Annot (e',tau') ->
         "(" ^ pretty_string_of_t e' ^ " : " ^ Type.string_of_t tau' ^ ")"
       | Let (e1, x, e2) -> "let " ^ string_of_int x ^ " = " ^ pretty_string_of_t e1 ^ " in " ^ pretty_string_of_t e2
-      | LExpr le -> LambdaC.Expr.pretty_string_of_t le
+      | LExpr le ->
+        "Delta" ^
+        LambdaC.Expr.pretty_string_of_t le
       | Phase (a, t) -> "<" ^ LambdaC.Expr.pretty_string_of_t a ^ "> " ^ pretty_string_of_t t
       | Prod (t1, t2) -> "(" ^ pretty_string_of_t t1 ^ ") * (" ^ pretty_string_of_t t2 ^ ")"
       | Pow (t, a) -> "(" ^ pretty_string_of_t t ^ ")^(" ^ LambdaC.Expr.pretty_string_of_t a ^ ")"

--- a/lib/lambdaPC.ml
+++ b/lib/lambdaPC.ml
@@ -22,7 +22,6 @@ end
 module Variable = LambdaC.Variable
 module VariableMap = LambdaC.VariableMap
 
-
 module Expr = struct
 
   type t =

--- a/lib/lambdaPC.mli
+++ b/lib/lambdaPC.mli
@@ -43,7 +43,7 @@ module HOAS : sig
   val fresh : unit -> Variable.t
 
   val var : Variable.t -> Expr.t
-  val letin : Expr.t -> (Variable.t -> Expr.t) -> Expr.t
+  val letin : Expr.t -> (Expr.t -> Expr.t) -> Expr.t
   val vec : LambdaC.Expr.t -> Expr.t
   val phase : LambdaC.Expr.t -> Expr.t -> Expr.t
   val ( * ) : Expr.t -> Expr.t -> Expr.t
@@ -51,11 +51,17 @@ module HOAS : sig
   val caseofP : Expr.t -> Expr.t -> Expr.t -> Expr.t
   val in1 : Expr.t -> Type.t -> Expr.t
   val in2 : Type.t -> Expr.t -> Expr.t
-  val caseof : Expr.t -> (Variable.t -> Expr.t) -> (Variable.t -> Expr.t) -> Expr.t
-  val lambda : Type.t -> (Variable.t -> Expr.t) -> Expr.pc
+  val caseof : Expr.t -> (Expr.t -> Expr.t) -> (Expr.t -> Expr.t) -> Expr.t
+  val lambda : Type.t -> (Expr.t -> Expr.t) -> Expr.pc
   val (@) : Expr.pc -> Expr.t -> Expr.t
   val suspend : Expr.t -> Expr.p
   val force : Expr.p -> Expr.t
+end
+
+module SymplecticForm : sig
+  val psi_of : Expr.t -> LambdaC.Expr.t
+  val ccaseP : LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t
+  val omega : Type.t -> LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t 
 end
 
 module PhaseEnvironment : (Zd : Scalars.Z_SIG) ->

--- a/lib/lambdaPC.mli
+++ b/lib/lambdaPC.mli
@@ -60,6 +60,7 @@ end
 
 module SymplecticForm : sig
   val psi_of : Expr.t -> LambdaC.Expr.t
+  val psi_of_pc : Expr.pc -> LambdaC.Expr.t
   val ccaseP : LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t
   val omega : Type.t -> LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t 
 end

--- a/lib/lambdaPC.mli
+++ b/lib/lambdaPC.mli
@@ -1,6 +1,7 @@
 module Type : sig
     type t = Pauli | PTensor of t*t
     val ltype_of_t : t -> LambdaC.Type.t
+    val t_of_ltype : LambdaC.Type.t -> t option
     val string_of_t : t -> string
 end
 module Variable = LambdaC.Variable
@@ -9,11 +10,12 @@ module Expr :
   sig
     type t =
         Var of Variable.t
+      | Annot of t * Type.t
       | Let of t * Variable.t * t
       | LExpr of LambdaC.Expr.t
       | Phase of LambdaC.Expr.t * t
       | Prod of t * t
-      | Pow of t * int
+      | Pow of t * LambdaC.Expr.t
       | CasePauli of t * t * t
       | In1 of t * Type.t
       | In2 of Type.t * t
@@ -47,7 +49,7 @@ module HOAS : sig
   val vec : LambdaC.Expr.t -> Expr.t
   val phase : LambdaC.Expr.t -> Expr.t -> Expr.t
   val ( * ) : Expr.t -> Expr.t -> Expr.t
-  val pow : Expr.t -> int -> Expr.t
+  val pow : Expr.t -> LambdaC.Expr.t -> Expr.t
   val caseofP : Expr.t -> Expr.t -> Expr.t -> Expr.t
   val in1 : Expr.t -> Type.t -> Expr.t
   val in2 : Type.t -> Expr.t -> Expr.t

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -52,6 +52,7 @@ rule read =
   | "[" {LSQUARE}
   | "]" {RSQUARE}
 
-  | id { ID (String.hash (Lexing.lexeme lexbuf)) }
   | int { INT (int_of_string (Lexing.lexeme lexbuf)) }
+  | id { ID (String.hash (Lexing.lexeme lexbuf)) }
+
   | eof { EOF }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -153,6 +153,8 @@ expr:
 
   | CASE t=expr OF LCURLY XCONST ARROW tx=expr MID ZCONST ARROW tz=expr RCURLY
     { Expr.CasePauli (t, tx, tz) }
+  | CASE t=expr OF LCURLY ZCONST ARROW tz=expr MID XCONST ARROW tx=expr RCURLY
+    { Expr.CasePauli (t, tx, tz) }
 
   | IN1 LCURLY tp=ptype RCURLY t=expr
     { Expr.In1 (t, tp) }
@@ -160,6 +162,9 @@ expr:
     { Expr.In2 (tp, t) }
   | CASE t=expr OF LCURLY IN1 x1=ID ARROW t1=expr
                    MID    IN2 x2=ID ARROW t2=expr RCURLY
+    { Expr.CasePTensor (t, x1, t1, x2, t2) }
+  | CASE t=expr OF LCURLY IN2 x2=ID ARROW t2=expr
+                   MID    IN1 x1=ID ARROW t1=expr RCURLY
     { Expr.CasePTensor (t, x1, t1, x2, t2) }
 
   | f=pclif AT t=expr

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -145,9 +145,11 @@ expr:
     { Expr.Prod (t1, t2) }
   
   | t=expr CARROT n=INT
-    { Expr.Pow (t, n) }
+    { Expr.Pow (t, LambdaC.Expr.Const n) }
   | t=expr CARROT LCURLY n=INT RCURLY
-    { Expr.Pow (t, n) }
+    { Expr.Pow (t, LambdaC.Expr.Const n) }
+  | t=expr CARROT LCURLY a=lexpr RCURLY
+    { Expr.Pow (t, a) }
 
   | CASE t=expr OF LCURLY XCONST ARROW tx=expr MID ZCONST ARROW tz=expr RCURLY
     { Expr.CasePauli (t, tx, tz) }

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -105,8 +105,13 @@ module SmtLambdaC (Zd : Z_SIG) = struct
   let rec smtml_of_expr (ctx : Smtml.Symbol.t VariableMap.t) (a : Expr.t) tp =
     match a with
     | Var x -> var ctx x
+    | Let (Annot(a1, tp1),x,a2) ->
+
+        let e1 = smtml_of_expr ctx a1 tp1 in
+        let s = make_symbol tp1 x in
+        let e2 = smtml_of_expr (VariableMap.add x s ctx) a2 tp in
+        Smtml.Expr.let_in [Smtml.Expr.symbol s; e1] e2
     | Zero tp -> zero tp
-    | ZeroA (tp,_) -> zero tp
     | Annot (a, _) -> smtml_of_expr ctx a tp
     | Plus (e1, e2) -> plus tp (smtml_of_expr ctx e1 tp) (smtml_of_expr ctx e2 tp)
     | Const r -> const r

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -14,12 +14,31 @@ module SMT = struct
     let e' = snd out_tp e1 in
     Expr.let_in [x; e2] e'
 
+
+  module Z3 = Smtml.Solver.Batch (Smtml.Z3_mappings)
+  let solver = Z3.create ()
+  type result =
+      Equivalent
+    | NotEquivalent of Model.t
+    | Unknown
+
+  let is_equiv tp e1 e2 : result =
+    let cond = Expr.unop Ty_bool Not (Expr.relop tp Eq e1 e2) in
+    Z3.add solver [ cond ];
+    match Z3.check solver [] with
+    | `Sat -> 
+        let model = Z3.model solver |> Option.get in
+        NotEquivalent model
+    | `Unsat -> Equivalent
+    | `Unknown -> Unknown
+
 end
 
-module SmtLambdaC (D : FIN) = struct
+module SmtLambdaC (Zd : Z_SIG) = struct
   open LambdaC
+  module EvalZd = Eval(Zd)
 
-  let modd e = Smtml.Expr.binop Ty_int Rem e (Smtml.Expr.value (Int D.dim))
+  let modd e = Smtml.Expr.binop Ty_int Rem e (Smtml.Expr.value (Int Zd.Dim.dim))
   let ( + ) e1 e2 = modd @@ Smtml.Expr.binop Ty_int Add e1 e2
   let ( * ) e1 e2 = modd @@ Smtml.Expr.binop Ty_int Mul e1 e2
 
@@ -29,20 +48,23 @@ module SmtLambdaC (D : FIN) = struct
     | Sum (_, _) -> Smtml.Ty.Ty_list
     | Arrow (_, _) -> Smtml.Ty.Ty_list
 
-  let var (ctx : Smtml.Expr.t VariableMap.t) (x : LambdaC.Variable.t) : Smtml.Expr.t =
-    VariableMap.find x ctx
-  let const (r : int) : Smtml.Expr.t = Smtml.Expr.value (Int (r mod D.dim))
+  let var (ctx : Smtml.Symbol.t VariableMap.t) (x : LambdaC.Variable.t) : Smtml.Expr.t =
+    Smtml.Expr.symbol @@ VariableMap.find x ctx
+  let const (r : int) : Smtml.Expr.t = Smtml.Expr.value (Int (r mod Zd.Dim.dim))
 
   let lambda x e = SMT.lambda x e
   let apply tp1 tp2 e1 e2 = SMT.apply (smtml_of_type tp1) (smtml_of_type tp2) e1 e2
 
-  let make_symbol tp = Smtml.Symbol.make (smtml_of_type tp) ("x")
+  let make_symbol tp x = Smtml.Symbol.make (smtml_of_type tp) ("x" ^ string_of_int x)
+  let fresh_symbol tp = 
+    let x = LambdaC.HOAS.fresh () in
+    make_symbol tp x
 
   let rec zero (tp : Type.t) : Smtml.Expr.t =
     match tp with
     | Unit -> const 0
     | Sum (tp1, tp2) -> SMT.pair (zero tp1) (zero tp2)
-    | Arrow(tp1, tp2) -> lambda (make_symbol tp1) (zero tp2)
+    | Arrow(tp1, tp2) -> lambda (fresh_symbol tp1) (zero tp2)
 
   let fst tp1 e = SMT.fst (smtml_of_type tp1) e
   let snd tp2 e = SMT.snd (smtml_of_type tp2) e
@@ -55,7 +77,7 @@ module SmtLambdaC (D : FIN) = struct
         let e2' = plus tp2 (snd tp2 e1) (snd tp2 e2) in
         (SMT.pair e1' e2')
     | Arrow(tp1, tp2) ->
-        let x = make_symbol tp1 in
+        let x = fresh_symbol tp1 in
         lambda x 
           (plus tp2 (apply tp1 tp2 e1 (Smtml.Expr.symbol x))
                     (apply tp1 tp2 e2 (Smtml.Expr.symbol x)))
@@ -68,7 +90,7 @@ module SmtLambdaC (D : FIN) = struct
       let e2' = scale tp2 e (snd tp2 e') in
       SMT.pair e1' e2'
     | Arrow(tp1, tp2) ->
-      let x = make_symbol tp1 in
+      let x = fresh_symbol tp1 in
       lambda x (scale tp2 e (apply tp1 tp2 e' (Smtml.Expr.symbol x)))
 
   let case tp1 tp2 tp' e x1 e1 x2 e2 =
@@ -78,8 +100,9 @@ module SmtLambdaC (D : FIN) = struct
     let e2' = apply tp2 tp' (lambda x2 e2) v2 in
     plus tp' e1' e2'
   
-  exception TypeError
-  let rec smtml_of_expr (ctx : Smtml.Expr.t VariableMap.t) (a : Expr.t) tp =
+  exception TypeError of (string * Expr.t list * Type.t option)
+
+  let rec smtml_of_expr (ctx : Smtml.Symbol.t VariableMap.t) (a : Expr.t) tp =
     match a with
     | Var x -> var ctx x
     | Zero tp -> zero tp
@@ -94,36 +117,133 @@ module SmtLambdaC (D : FIN) = struct
           let e1' = smtml_of_expr ctx e1 tp1 in
           let e2' = smtml_of_expr ctx e2 tp2 in
           SMT.pair e1' e2'
-        | _ -> raise TypeError
+        | _ -> raise @@ TypeError ("[smtml_of_expr] Expressions of the form (-,-) must have sum type", [a], Some tp)
       )
 
-    (* The annotations here are fairly restrictive, try to make this better *)
+    (* The annotations here are fairly restrictive, try to make this better using the typechecker/type inference *)
     | Case (Annot (e, Sum(tp1, tp2)), x1, e1, x2, e2) ->
-      let x1' = make_symbol tp1 in
-      let x2' = make_symbol tp2 in
-      let ctx1 = VariableMap.add x1 (Smtml.Expr.symbol x1') ctx in
-      let ctx2 = VariableMap.add x2 (Smtml.Expr.symbol x2') ctx in
+      let s1 = make_symbol tp1 x1 in
+      let s2 = make_symbol tp2 x2 in
+      let ctx1 = VariableMap.add x1 s1 ctx in
+      let ctx2 = VariableMap.add x2 s2 ctx in
       let e' = smtml_of_expr ctx e (Sum (tp1, tp2)) in
       let e1' = smtml_of_expr ctx1 e1 tp in
       let e2' = smtml_of_expr ctx2 e2 tp in
-      case tp1 tp2 tp e' x1' e1' x2' e2'
+      case tp1 tp2 tp e' s1 e1' s2 e2'
 
     | Lambda (x,_,e') ->
       ( match tp with
         | Arrow (tp1, tp2) -> 
-          let x' = make_symbol tp1 in
-          let ctx' = VariableMap.add x (Smtml.Expr.symbol x') ctx in
+          let s = make_symbol tp1 x in
+          let ctx' = VariableMap.add x s ctx in
           let e' = smtml_of_expr ctx' e' tp2 in
-          lambda x' e'
-        | _ -> raise TypeError
+          lambda s e'
+        | _ -> raise @@ TypeError ("[smtml_of_expr] Expressions of the form Lambda(-,-,-) must have function type",
+                                  [a],
+                                  Some tp)
       )
 
     (* The annotations here are fairly restrictive, try to make this better *)
     | Apply (Annot (e1, Sum(tp1, tp2)), e2) ->
       apply tp1 tp2 (smtml_of_expr ctx e1 (Sum(tp1, tp2))) (smtml_of_expr ctx e2 tp1)
 
+    | _ -> raise @@ TypeError ("[smtml_of_expr]", [a], Some tp)
 
-    | _ -> raise TypeError
+  (*
+  let rec free_variables (a : Expr.t) : LambdaC.UsageContext.t =
+    match a with 
+    | Var x -> UsageContext.singleton x
+    | Zero _ -> UsageContext.empty (* ?? *)
+    | ZeroA (_,ctx) -> ctx
+    | Annot (a, _) -> free_variables a
+    | Plus (a1,a2) -> free_variables a1 `union` free_variables a2
+    | Const r -> UsageContext.empty
+    | Scale (a1, a2) -> free_variables a1 `union` free_variables a2
+    | Pair (a1, a2) -> free_variables a1 `union` free_variables a2
+    | Case (a',x1,a1,x2,a2) ->
+        let vars1 = remove x1 (free_variables a1) in
+        let vars2 = remove x2 (free_variables a2) in
+        free_variables a' `union` vars1 `union` vars2
+    | Lambda (x,_,a') -> remove x (free_variables a')
+    | Apply (a1,a2) -> free_variables a1 `union` free_variables a2
+  *)
 
+  let rec value_of_smtml (tp : Type.t) (v : Smtml.Value.t) : Val.t =
+    match tp, v with
+    | Unit, Int r -> Val.Const r
+    | Sum (tp1,tp2), List [v1; v2] -> Val.Pair (value_of_smtml tp1 v1, value_of_smtml tp2 v2)
+    | Arrow (_, _), List [_;_] -> 
+      raise @@ TypeError ("[smtml] Cannot coerce smtml value to LambdaC value of function type", [], Some tp)
+    | _, _ -> 
+      raise @@ TypeError ("[smtml] Cannot find LambdaC value corresponding to the given smtml value", [], Some tp)
+
+  module VariableMap = LambdaC.VariableMap
+  (* When we encounter a free variable in a, add a binding to the corresponding symbol *)
+  let make_symbol_map (ctx : LambdaC.Type.t VariableMap.t) : Smtml.Symbol.t VariableMap.t =
+    let f x tp = make_symbol tp x in
+    VariableMap.mapi f ctx
+
+
+  let instantiate model (x : Variable.t) (tp : Type.t) : Val.t =
+    let s = make_symbol tp x in
+    let v0 = Smtml.Model.evaluate model s |> Option.get in
+    value_of_smtml tp v0
+
+  let counterexample_of_model (ctx : Type.t VariableMap.t) model : Val.t VariableMap.t =
+    VariableMap.mapi (instantiate model) ctx
+ 
+  
+  type counterexample = {
+    inputs : Val.t VariableMap.t;
+    lhs : Val.t;
+    rhs : Val.t
+  }
+  let equiv (tp : Type.t) (ctx : Type.t VariableMap.t) (a1 : Expr.t) (a2 : Expr.t) : (unit, counterexample) result =
+    let ctx0 = make_symbol_map ctx in
+
+    let e1 = smtml_of_expr ctx0 a1 tp in
+    let e2 = smtml_of_expr ctx0 a2 tp in
+
+    match SMT.is_equiv (smtml_of_type tp) e1 e2 with
+    | Equivalent -> Ok ()
+    | NotEquivalent model ->
+        let counter = counterexample_of_model ctx model in
+        let v1 = EvalZd.eval counter a1 in
+        let v2 = EvalZd.eval counter a2 in
+      Error 
+        { inputs = counterexample_of_model ctx model;
+        lhs = v1;
+        rhs = v2
+        }
+    | Unknown -> raise @@ TypeError ("[SmtLambdaC.equiv] Solver timeout", [a1;a2], Some tp)
+    
+end
+
+
+
+module SmtLambdaPC (S : SCALARS) = struct
+  module SmtC = SmtLambdaC (S.Zd)
+
+  let symplectic_check in_tp out_tp (f : LambdaPC.Expr.pc) : (unit, SmtC.counterexample) result =
+    match f with
+    | Lam(x,_,t) ->
+        let in_tp' = LambdaPC.Type.ltype_of_t in_tp in
+
+        (* create the expression lhs = omega(psiof(t)[x1/x],psiof(t)[x2/x])*)
+        let a = LambdaPC.SymplecticForm.psi_of t in
+        LambdaC.HOAS.update_env a;
+        let x1 = LambdaC.HOAS.fresh () in
+        let x2 = LambdaC.HOAS.fresh () in
+        let a1 = LambdaC.Expr.rename_var x x1 a in
+        let a2 = LambdaC.Expr.rename_var x x2 a in
+        let lhs = LambdaPC.SymplecticForm.omega out_tp a1 a2 in
+
+        (* create the expression rhs = omega(x1,x2) *)
+        let rhs = LambdaPC.SymplecticForm.omega in_tp (LambdaC.HOAS.var x1) (LambdaC.HOAS.var x2) in
+
+        (* check for equivalence *)
+        let ctx = LambdaC.VariableMap.of_list [(x1,in_tp'); (x2,in_tp')] in
+        
+        SmtC.equiv LambdaC.Type.Unit ctx lhs rhs
 
 end

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -463,7 +463,7 @@ module SmtLambdaC (Zd : Z_SIG) = struct
 
   let var (ctx : Smtml.Symbol.t VariableMap.t) (x : LambdaC.Variable.t) : Smtml.Expr.t =
     Smtml.Expr.symbol @@ VariableMap.find x ctx
-  let const (r : int) : Smtml.Expr.t = Smtml.Expr.value (Int (r mod Zd.Dim.dim))
+  let const (r : int) : Smtml.Expr.t = modd (Smtml.Expr.value (Int r))
 
   (*
   let lambda x e = SMT.lambda x e
@@ -654,7 +654,7 @@ module SmtLambdaC (Zd : Z_SIG) = struct
 
   let rec value_of_smtml (tp : Type.t) (v : Smtml.Value.t) : Val.t =
     match tp, v with
-    | Unit, Int r -> Val.Const r
+    | Unit, Int r -> Val.Const (Zd.normalize r)
     | Sum (tp1,tp2), List [v1; v2] -> Val.Pair (value_of_smtml tp1 v1, value_of_smtml tp2 v2)
     | Arrow (_, _), List [_;_] -> 
       terr @@ "[smtml] Cannot coerce smtml value to LambdaC value of function type\n"

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -246,4 +246,5 @@ module SmtLambdaPC (S : SCALARS) = struct
         
         SmtC.equiv LambdaC.Type.Unit ctx lhs rhs
 
+      
 end

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -1,0 +1,129 @@
+open Scalars
+
+module SMT = struct
+  open Smtml
+
+  let pair e1 e2 = Expr.list [e1; e2]
+  let fst tp e = Expr.unop tp Ty.Unop.Head e
+  let snd tp e = fst tp (Expr.unop Ty.Ty_list Ty.Unop.Tail e)
+  let lambda (x : Symbol.t) (e : Expr.t) = Smtml.Expr.list [Smtml.Expr.symbol x; e]
+
+  let apply in_tp out_tp e1 e2 = 
+    (* Assume e1 is a pair corresponding to an smt_lambda, e2 is a value *)
+    let x = fst in_tp e1 in
+    let e' = snd out_tp e1 in
+    Expr.let_in [x; e2] e'
+
+end
+
+module SmtLambdaC (D : FIN) = struct
+  open LambdaC
+
+  let modd e = Smtml.Expr.binop Ty_int Rem e (Smtml.Expr.value (Int D.dim))
+  let ( + ) e1 e2 = modd @@ Smtml.Expr.binop Ty_int Add e1 e2
+  let ( * ) e1 e2 = modd @@ Smtml.Expr.binop Ty_int Mul e1 e2
+
+  let smtml_of_type (tp : LambdaC.Type.t) : Smtml.Ty.t =
+    match tp with
+    | Unit -> Smtml.Ty.Ty_int
+    | Sum (_, _) -> Smtml.Ty.Ty_list
+    | Arrow (_, _) -> Smtml.Ty.Ty_list
+
+  let var (ctx : Smtml.Expr.t VariableMap.t) (x : LambdaC.Variable.t) : Smtml.Expr.t =
+    VariableMap.find x ctx
+  let const (r : int) : Smtml.Expr.t = Smtml.Expr.value (Int (r mod D.dim))
+
+  let lambda x e = SMT.lambda x e
+  let apply tp1 tp2 e1 e2 = SMT.apply (smtml_of_type tp1) (smtml_of_type tp2) e1 e2
+
+  let make_symbol tp = Smtml.Symbol.make (smtml_of_type tp) ("x")
+
+  let rec zero (tp : Type.t) : Smtml.Expr.t =
+    match tp with
+    | Unit -> const 0
+    | Sum (tp1, tp2) -> SMT.pair (zero tp1) (zero tp2)
+    | Arrow(tp1, tp2) -> lambda (make_symbol tp1) (zero tp2)
+
+  let fst tp1 e = SMT.fst (smtml_of_type tp1) e
+  let snd tp2 e = SMT.snd (smtml_of_type tp2) e
+
+  let rec plus (tp : Type.t) e1 e2 =
+    match tp with
+    | Unit -> e1 + e2
+    | Sum(tp1, tp2) ->
+        let e1' = plus tp1 (fst tp1 e1) (fst tp1 e2) in
+        let e2' = plus tp2 (snd tp2 e1) (snd tp2 e2) in
+        (SMT.pair e1' e2')
+    | Arrow(tp1, tp2) ->
+        let x = make_symbol tp1 in
+        lambda x 
+          (plus tp2 (apply tp1 tp2 e1 (Smtml.Expr.symbol x))
+                    (apply tp1 tp2 e2 (Smtml.Expr.symbol x)))
+
+  let rec scale (tp : Type.t) e e' =
+    match tp with
+    | Unit -> e * e'
+    | Sum(tp1, tp2) ->
+      let e1' = scale tp1 e (fst tp1 e') in
+      let e2' = scale tp2 e (snd tp2 e') in
+      SMT.pair e1' e2'
+    | Arrow(tp1, tp2) ->
+      let x = make_symbol tp1 in
+      lambda x (scale tp2 e (apply tp1 tp2 e' (Smtml.Expr.symbol x)))
+
+  let case tp1 tp2 tp' e x1 e1 x2 e2 =
+    let v1 = fst tp1 e in
+    let v2 = snd tp2 e in
+    let e1' = apply tp1 tp' (lambda x1 e1) v1 in
+    let e2' = apply tp2 tp' (lambda x2 e2) v2 in
+    plus tp' e1' e2'
+  
+  exception TypeError
+  let rec smtml_of_expr (ctx : Smtml.Expr.t VariableMap.t) (a : Expr.t) tp =
+    match a with
+    | Var x -> var ctx x
+    | Zero tp -> zero tp
+    | ZeroA (tp,_) -> zero tp
+    | Annot (a, _) -> smtml_of_expr ctx a tp
+    | Plus (e1, e2) -> plus tp (smtml_of_expr ctx e1 tp) (smtml_of_expr ctx e2 tp)
+    | Const r -> const r
+    | Scale (e1, e2) -> scale tp (smtml_of_expr ctx e1 Type.Unit) (smtml_of_expr ctx e2 tp)
+    | Pair (e1, e2) ->
+      ( match tp with
+        | Sum (tp1, tp2) ->
+          let e1' = smtml_of_expr ctx e1 tp1 in
+          let e2' = smtml_of_expr ctx e2 tp2 in
+          SMT.pair e1' e2'
+        | _ -> raise TypeError
+      )
+
+    (* The annotations here are fairly restrictive, try to make this better *)
+    | Case (Annot (e, Sum(tp1, tp2)), x1, e1, x2, e2) ->
+      let x1' = make_symbol tp1 in
+      let x2' = make_symbol tp2 in
+      let ctx1 = VariableMap.add x1 (Smtml.Expr.symbol x1') ctx in
+      let ctx2 = VariableMap.add x2 (Smtml.Expr.symbol x2') ctx in
+      let e' = smtml_of_expr ctx e (Sum (tp1, tp2)) in
+      let e1' = smtml_of_expr ctx1 e1 tp in
+      let e2' = smtml_of_expr ctx2 e2 tp in
+      case tp1 tp2 tp e' x1' e1' x2' e2'
+
+    | Lambda (x,_,e') ->
+      ( match tp with
+        | Arrow (tp1, tp2) -> 
+          let x' = make_symbol tp1 in
+          let ctx' = VariableMap.add x (Smtml.Expr.symbol x') ctx in
+          let e' = smtml_of_expr ctx' e' tp2 in
+          lambda x' e'
+        | _ -> raise TypeError
+      )
+
+    (* The annotations here are fairly restrictive, try to make this better *)
+    | Apply (Annot (e1, Sum(tp1, tp2)), e2) ->
+      apply tp1 tp2 (smtml_of_expr ctx e1 (Sum(tp1, tp2))) (smtml_of_expr ctx e2 tp1)
+
+
+    | _ -> raise TypeError
+
+
+end

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -149,8 +149,8 @@ module SmtLambdaC (Zd : Z_SIG) = struct
       )
 
     (* The annotations here are fairly restrictive, try to make this better *)
-    | Apply (Annot (e1, Sum(tp1, tp2)), e2) ->
-      apply tp1 tp2 (smtml_of_expr ctx e1 (Sum(tp1, tp2))) (smtml_of_expr ctx e2 tp1)
+    | Apply (Annot (e1, Arrow(tp1, tp2)), e2) ->
+      apply tp1 tp2 (smtml_of_expr ctx e1 (Arrow(tp1, tp2))) (smtml_of_expr ctx e2 tp1)
 
     | _ -> raise @@ TypeError ("[smtml_of_expr]", [a], Some tp)
 

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -288,7 +288,6 @@ module SmtLambdaCExpr = struct
           then exists e such that gamma(x)=e
           and ctx' |- e : tau
        *)
-    [@@@warning "-32"]
     let eta ctx : Expr.t VariableMap.t * Type.t VariableMap.t =
 
       let expand x tp (gamma0,ctx0) =

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -1,0 +1,58 @@
+open LambdaPC
+
+module LinearityTyping : sig
+  type type_information = (LambdaPC.Type.t, LambdaPC.Expr.t) LambdaC.TypeInformation.t
+
+  val string_of_info : type_information -> string
+  val pp_info : type_information -> unit
+
+  val typecheck' : Type.t VariableMap.t -> Expr.t -> type_information
+  val linearity_check : Expr.t -> type_information
+  val linearity_check_pc : Expr.pc -> (LambdaPC.Type.t * LambdaPC.Type.t, LambdaPC.Expr.pc) LambdaC.TypeInformation.t
+end
+
+module SmtLambdaCExpr : sig
+  open LambdaC
+    type normal =
+      NConst of int
+    | NLambda of Variable.t * Type.t * normal
+    | NPair of normal * normal
+    | Annot of neutral * Type.t
+    | Neutral of neutral
+    and neutral =
+      NVar of Variable.t
+    | NApply of neutral * normal
+    | NCase of neutral * Variable.t * normal * Variable.t * normal
+    | NPlus of neutral * normal
+    | NScale of normal * neutral
+
+  (* Normalized expressions do not contain Zero or
+     Let statements.
+     Normalized expressions preserve types but NOT linearity checking.
+     If an arrow type -o does not occur in the free variables of an expression or in its result type,
+     then its normalization should not contain any instances of Lambda or Apply
+  *)
+  val normalize : LambdaC.Expr.t -> LambdaC.Expr.t
+end
+
+module SmtLambdaC :
+  (_ : Scalars.Z_SIG) -> sig
+  open LambdaC
+    val smtml_of_type : LambdaC.Type.t -> Smtml.Ty.t
+    val smtml_of_expr : Type.t VariableMap.t -> Smtml.Symbol.t VariableMap.t -> Expr.t -> Type.t -> Smtml.Expr.t
+    val value_of_smtml : Type.t -> Smtml.Value.t -> Val.t
+
+    type counterexample = {
+      inputs : Val.t VariableMap.t;
+      lhs : Val.t;
+      rhs : Val.t
+    }
+
+    val equiv : Type.t -> Type.t VariableMap.t -> Expr.t -> Expr.t -> (unit, counterexample) result
+  end
+
+module SmtLambdaPC :
+  (_ : Scalars.SCALARS) -> sig
+  val symplectic_check : Type.t -> Type.t -> LambdaPC.Expr.pc -> unit
+  val typecheck : LambdaPC.Expr.pc -> Type.t * Type.t
+end

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -42,11 +42,11 @@ module SmtLambdaC :
     val smtml_of_expr : Type.t VariableMap.t -> Smtml.Symbol.t VariableMap.t -> Expr.t -> Type.t -> Smtml.Expr.t
     val value_of_smtml : Type.t -> Smtml.Value.t -> Val.t
 
-    type counterexample = {
-      inputs : Val.t VariableMap.t;
-      lhs : Val.t;
-      rhs : Val.t
-    }
+  type counterexample = {
+    inputs : Val.t VariableMap.t;
+    lhs : Val.t;
+    rhs : Val.t
+  }
 
     val equiv : Type.t -> Type.t VariableMap.t -> Expr.t -> Expr.t -> (unit, counterexample) result
   end

--- a/test/test_lambdaC.ml
+++ b/test/test_lambdaC.ml
@@ -88,14 +88,14 @@ let suite =
 
       test_case "Testing function application" `Quick (fun () ->
         TestEval2.test_eval
-          HOAS.(lambda Unit (fun x -> var x + var x) @ (const 3))
+          HOAS.(lambda Unit (fun x -> x + x) @ (const 3))
           HOAS.(const 6)
         );
 
       test_case "Testing case evaluation" `Quick (fun () ->
         TestEval2.test_eval
           HOAS.(case (Expr.Pair(const 1, const 0))
-            (fun x1 -> var x1)
+            (fun x1 -> x1)
             (fun _ -> const 11)
           )
           HOAS.(const 12)


### PR DESCRIPTION
This PR adds typechecking to the language. It includes linear typechecking for both lambdaC and lambdaPC, and an SMT-based symplectomorphism check for pc functions. We will make improvements to the symplectomorphism check in the future.