### PR TITLE
Updating ASTs in the language to use Ident.t

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,15 @@ To interact with PCLib through the parser, use `open PCLib.Interface`. This expo
 
 ## Installation
 
-The repository uses the dune build system (https://dune.build/install). Operations include:
+To build LambdaPC, you will need to install ocaml (https://ocaml.org/install), including the package manager opam.
+You will then need to install the dune build system (https://dune.build) and the smtml library (https://github.com/formalsec/smtml) via opam:
+
+```
+    $ opam install dune
+    $ opam install smtml
+```
+
+You should then be able to build LambdaPC:
 
 * `dune build` - build the library
 * `dune exec LambdaPC` - run the `main` file, which currently calls out to `lib/examples.ml`

--- a/lib/core/typing.ml
+++ b/lib/core/typing.ml
@@ -1,7 +1,8 @@
 open Scalars
+open Ident
 open LambdaPC
 
-module VariableSet = LambdaC.VariableSet
+module VariableSet = IdentSet
 module TypeInformation = LambdaC.TypeInformation
 open TypeInformation
 
@@ -265,20 +266,20 @@ module SmtLambdaCExpr = struct
     *)
 
     let concat = VariableMap.union (fun _ _ _ -> None)
-    let rec eta_expand_var env tp : Type.t VariableMap.t * Expr.t =
+    let rec eta_expand_var tp : Type.t VariableMap.t * Expr.t =
       match tp with
       | Type.Unit ->
-          let x = VariableEnvironment.fresh env in
+          let x = Ident.fresh() in
           (VariableMap.singleton x Type.Unit, Var x)
       | Type.Sum(tp1,tp2) ->
-          let (gamma1,e1) = eta_expand_var env tp1 in
-          let (gamma2,e2) = eta_expand_var env tp2 in
+          let (gamma1,e1) = eta_expand_var tp1 in
+          let (gamma2,e2) = eta_expand_var tp2 in
           (* gamma1(x1)=e1 such that ctx1 |- e1 :  *)
           (concat gamma1 gamma2, Pair(e1,e2))
       | _ -> terr "Called eta_expand_var on function type"
 
     let string_of_VariableMap string_of_a gamma =
-      "[" ^ VariableMap.fold (fun x tp s -> string_of_int x ^ " : " ^ string_of_a tp ^ ", " ^ s) gamma "]\n"
+      "[" ^ VariableMap.fold (fun x tp s -> Ident.string_of_t x ^ " : " ^ string_of_a tp ^ ", " ^ s) gamma "]\n"
     
 
     (* The result of eta ctx should be a substitution map gamma
@@ -291,7 +292,7 @@ module SmtLambdaCExpr = struct
     let eta ctx : Expr.t VariableMap.t * Type.t VariableMap.t =
 
       let expand x tp (gamma0,ctx0) =
-        let (ctx',a') = eta_expand_var !HOAS.var_env tp in
+        let (ctx',a') = eta_expand_var tp in
         (VariableMap.add x a' gamma0, concat ctx0 ctx')
       in
 
@@ -311,24 +312,24 @@ module SmtLambdaCExpr = struct
     *)
     type normal =
       NConst of int
-    | NLambda of Variable.t * Type.t * normal
+    | NLambda of Ident.t * Type.t * normal
     | NPair of normal * normal
     | Annot of neutral * Type.t
     | Neutral of neutral
     and neutral =
-      NVar of Variable.t
+      NVar of Ident.t
     | NApply of neutral * normal
-    | NCase of neutral * Variable.t * normal * Variable.t * normal
+    | NCase of neutral * Ident.t * normal * Ident.t * normal
     | NPlus of neutral * normal
     | NScale of normal * neutral
 
-    let rec nzero env tp = 
+    let rec nzero tp = 
       match tp with
       | LambdaC.Type.Unit -> NConst 0
-      | Sum(tp1,tp2) -> NPair(nzero env tp1, nzero env tp2)
+      | Sum(tp1,tp2) -> NPair(nzero tp1, nzero tp2)
       | Arrow(tp1,tp2) ->
-        let x = VariableEnvironment.fresh env in
-        NLambda(x,tp1,nzero env tp2)
+        let x = Ident.fresh() in
+        NLambda(x,tp1,nzero tp2)
 
     
     let rec nscale e1 e2 =
@@ -352,75 +353,75 @@ module SmtLambdaCExpr = struct
       | Annot(e',_),_ -> Annot(e',tp)
       | _, _ -> failwith "[Typing.SmtLambdaC.Expr.annot] type mismatch"
 
-    let rec subst env from to_ e =
+    let rec subst from to_ e =
       match e with
       | NConst r -> NConst r
       | NLambda(x,tp,e') ->
-        if x=from then NLambda(x,tp,e') else NLambda(x,tp,subst env from to_ e')
-      | NPair(e1,e2) -> NPair(subst env from to_ e1, subst env from to_ e2)
-      | Neutral e' -> substN env from to_ e'
-      | Annot(e',tp) -> annot (substN env from to_ e') tp
-    and substN env from to_ e =
+        if x=from then NLambda(x,tp,e') else NLambda(x,tp,subst from to_ e')
+      | NPair(e1,e2) -> NPair(subst from to_ e1, subst from to_ e2)
+      | Neutral e' -> substN from to_ e'
+      | Annot(e',tp) -> annot (substN from to_ e') tp
+    and substN from to_ e =
       match e with
       | NVar x -> if x=from then to_ else Neutral (NVar x)
-      | NApply(e1,e2) -> napply env (substN env from to_ e1) (subst env from to_ e2) 
+      | NApply(e1,e2) -> napply (substN from to_ e1) (subst from to_ e2) 
       | NCase(e',x1,e1,x2,e2) ->
-        let e1' = if x1=from then e1 else subst env from to_ e1 in
-        let e2' = if x2=from then e2 else subst env from to_ e2 in
-        ncase env (substN env from to_ e') x1 e1' x2 e2'
-      | NPlus(e1,e2) -> nplus env (substN env from to_ e1) (subst env from to_ e2)
-      | NScale(e1,e2) -> nscale (subst env from to_ e1) (substN env from to_ e2)
+        let e1' = if x1=from then e1 else subst from to_ e1 in
+        let e2' = if x2=from then e2 else subst from to_ e2 in
+        ncase (substN from to_ e') x1 e1' x2 e2'
+      | NPlus(e1,e2) -> nplus (substN from to_ e1) (subst from to_ e2)
+      | NScale(e1,e2) -> nscale (subst from to_ e1) (substN from to_ e2)
 
 
-    and napply env e1 e2 =
+    and napply e1 e2 =
       match e1 with
-      | NLambda(x,_,e1') -> subst env x e2 e1'
+      | NLambda(x,_,e1') -> subst x e2 e1'
       | Neutral e1' -> Neutral (NApply(e1',e2))
       | Annot(e1',Arrow(_,tp2)) -> Annot (NApply(e1',e2), tp2)
       | _ -> failwith "[Typing.SmtLambdaC.Expr.napply] type mismatch"
 
-    and nplus env e1 e2 =
+    and nplus e1 e2 =
       match e1, e2 with
       | NConst r1, NConst r2 -> NConst (r1 + r2)
       | NLambda(x1,tp1,e1'), NLambda(x2,_,e2') ->
-        let x = VariableEnvironment.fresh env in
+        let x = Ident.fresh() in
         NLambda(x,tp1,
-          nplus env (subst env x1 (Neutral (NVar x)) e1')
-                    (subst env x2 (Neutral (NVar x)) e2'))
+          nplus (subst x1 (Neutral (NVar x)) e1')
+                    (subst x2 (Neutral (NVar x)) e2'))
       | NPair (e1',e1''), NPair(e2',e2'') ->
-        NPair(nplus env e1' e2', nplus env e1'' e2'')
+        NPair(nplus e1' e2', nplus e1'' e2'')
       | Neutral e1', _ -> Neutral (NPlus(e1',e2))
       | Annot(e1',tp), _ -> Annot(NPlus(e1',e2), tp)
       | _, Neutral e2' -> Neutral (NPlus(e2', e1))
       | _, _ -> failwith "[Typing.SmtLambdaC.Expr.nplus] type mismatch"
 
-    and ncase env e x1 e1 x2 e2 =
+    and ncase e x1 e1 x2 e2 =
       match e with
       | NPair(e1',e2') ->
-        nplus env (subst env x1 e1' e1) (subst env x2 e2' e2)
+        nplus (subst x1 e1' e1) (subst x2 e2' e2)
       | Neutral e' ->
         Neutral (NCase(e',x1,e1,x2,e2))
       | Annot(e',_) ->
         Neutral (NCase(e',x1,e1,x2,e2))
       | _ -> failwith "[Typing.SmtLambdaC.Expr.ncase] type mismatch"
 
-    let rec normalize' env (a : Expr.t) =
+    let rec normalize' (a : Expr.t) =
       match a with
       | Expr.Var x -> Neutral (NVar x)
       | Let(a1,x,a2) ->
-        subst env x (normalize' env a1) (normalize' env a2)
-      | Zero tp -> nzero env tp
-      | Annot(a',_) -> normalize' env a'
-      | Plus(a1,a2) -> nplus env (normalize' env a1) (normalize' env a2)
+        subst x (normalize' a1) (normalize' a2)
+      | Zero tp -> nzero tp
+      | Annot(a',_) -> normalize' a'
+      | Plus(a1,a2) -> nplus (normalize' a1) (normalize' a2)
       | Const r -> NConst r
-      | Scale(a1,a2) -> nscale (normalize' env a1) (normalize' env a2)
-      | Pair(a1,a2) -> NPair(normalize' env a1, normalize' env a2)
+      | Scale(a1,a2) -> nscale (normalize' a1) (normalize' a2)
+      | Pair(a1,a2) -> NPair(normalize' a1, normalize' a2)
       | Case(a',x1,a1,x2,a2) ->
-        ncase env (normalize' env a')
-              x1  (normalize' env a1)
-              x2  (normalize' env a2)
-      | Lambda(x,tp,a') -> NLambda(x,tp,normalize' env a')
-      | Apply(a1,a2) -> napply env (normalize' env a1) (normalize' env a2)
+        ncase (normalize' a')
+              x1  (normalize' a1)
+              x2  (normalize' a2)
+      | Lambda(x,tp,a') -> NLambda(x,tp,normalize' a')
+      | Apply(a1,a2) -> napply (normalize' a1) (normalize' a2)
 
     let rec expr_of_normal (e : normal) : Expr.t =
       match e with
@@ -439,8 +440,8 @@ module SmtLambdaCExpr = struct
 
     let normalize a =
       debug @@  "Normalizing: " ^ Expr.pretty_string_of_t a ^ "\n";
-      HOAS.update_env a;
-      let e = normalize' (!HOAS.var_env) a in
+      Expr.update_env a;
+      let e = normalize' a in
       let a' = expr_of_normal e in
       debug @@  "Got normalized expression: " ^ Expr.pretty_string_of_t a' ^ "\n";
       a'
@@ -461,7 +462,7 @@ module SmtLambdaC (Zd : Z_SIG) = struct
     | Sum (_, _) -> Smtml.Ty.Ty_list
     | Arrow (_, _) -> Smtml.Ty.Ty_list
 
-  let var (ctx : Smtml.Symbol.t VariableMap.t) (x : LambdaC.Variable.t) : Smtml.Expr.t =
+  let var (ctx : Smtml.Symbol.t VariableMap.t) (x : Ident.t) : Smtml.Expr.t =
     Smtml.Expr.symbol @@ VariableMap.find x ctx
   let const (r : int) : Smtml.Expr.t = modd (Smtml.Expr.value (Int r))
 
@@ -472,10 +473,10 @@ module SmtLambdaC (Zd : Z_SIG) = struct
 
   (* typed symbols are for free variables *)
   let make_typed_symbol tp x =
-    Smtml.Symbol.make (smtml_of_type tp) ("x" ^ string_of_int x)
+    Smtml.Symbol.make (smtml_of_type tp) ("x" ^ Ident.string_of_t x)
   (* untyped symbols are for bound variables *)
   let make_untyped_symbol x =
-    Smtml.Symbol.make Smtml.Ty.Ty_none ("x" ^ string_of_int x)
+    Smtml.Symbol.make Smtml.Ty.Ty_none ("x" ^ Ident.string_of_t x)
   (*
   [@@@warning "-32"]
   let fresh_symbol tp = 
@@ -665,18 +666,17 @@ module SmtLambdaC (Zd : Z_SIG) = struct
         ^ "\tValue: " ^ Smtml.Value.to_string v ^ "\n"
         ^ "\tType: " ^ Type.string_of_t tp ^ "\n"
 
-  module VariableMap = LambdaC.VariableMap
   (* When we encounter a free variable in a, add a binding to the corresponding symbol *)
   let make_symbol_map (ctx : LambdaC.Type.t VariableMap.t) : Smtml.Symbol.t VariableMap.t =
     let f x tp = make_typed_symbol tp x in
     VariableMap.mapi f ctx
 
 
-  let instantiate model (x : Variable.t) (tp : Type.t) : Val.t =
+  let instantiate model (x : Ident.t) (tp : Type.t) : Val.t =
     let s = make_typed_symbol tp x in
     match Smtml.Model.evaluate model s with
     | Some v0 -> value_of_smtml tp v0
-    | None -> terr @@ "Could not instantiate model of variable x" ^ string_of_int x ^ "\n"
+    | None -> terr @@ "Could not instantiate model of variable x" ^ Ident.string_of_t x ^ "\n"
 
   let counterexample_of_model (ctx : Type.t VariableMap.t) model : Val.t VariableMap.t =
     VariableMap.mapi (instantiate model) ctx
@@ -780,9 +780,9 @@ module SmtLambdaPC (S : SCALARS) = struct
         (* create the expression lhs = omega(psiof(t)[x1/x],psiof(t)[x2/x])*)
         let a = LambdaPC.SymplecticForm.psi_of t in
         debug @@ "Got LambdaC expression: " ^ LambdaC.Expr.pretty_string_of_t a ^ "\n";
-        LambdaC.HOAS.update_env a;
-        let x1 = LambdaC.HOAS.fresh () in
-        let x2 = LambdaC.HOAS.fresh () in
+        LambdaC.Expr.update_env a;
+        let x1 = Ident.fresh_like x in
+        let x2 = Ident.fresh_like x in
         let a1 = LambdaC.Expr.rename_var x x1 a in
         let a2 = LambdaC.Expr.rename_var x x2 a in
         let lhs = LambdaPC.SymplecticForm.omega out_tp a1 a2 in

--- a/lib/core/typing.ml
+++ b/lib/core/typing.ml
@@ -793,7 +793,7 @@ module SmtLambdaPC (S : SCALARS) = struct
         debug @@ "RHS: " ^ LambdaC.Expr.pretty_string_of_t rhs ^ "\n";
 
         (* check for equivalence *)
-        let ctx = LambdaC.VariableMap.of_list [(x1,in_tp'); (x2,in_tp')] in
+        let ctx = VariableMap.add x1 in_tp' (VariableMap.singleton x2 in_tp') in
         match SmtC.equiv LambdaC.Type.Unit ctx lhs rhs with
         | Ok _ -> ()
         | Error counter ->

--- a/lib/core/typing.mli
+++ b/lib/core/typing.mli
@@ -35,8 +35,7 @@ module SmtLambdaCExpr : sig
   val normalize : LambdaC.Expr.t -> LambdaC.Expr.t
 end
 
-module SmtLambdaC :
-  (_ : Scalars.Z_SIG) -> sig
+module SmtLambdaC : Scalars.Z_SIG -> sig
   open LambdaC
     val smtml_of_type : LambdaC.Type.t -> Smtml.Ty.t
     val smtml_of_expr : Type.t VariableMap.t -> Smtml.Symbol.t VariableMap.t -> Expr.t -> Type.t -> Smtml.Expr.t
@@ -51,8 +50,7 @@ module SmtLambdaC :
     val equiv : Type.t -> Type.t VariableMap.t -> Expr.t -> Expr.t -> (unit, counterexample) result
   end
 
-module SmtLambdaPC :
-  (_ : Scalars.SCALARS) -> sig
+module SmtLambdaPC : Scalars.SCALARS -> sig
   val symplectic_check : Type.t -> Type.t -> LambdaPC.Expr.pc -> unit
   val typecheck : LambdaPC.Expr.pc -> Type.t * Type.t
 end

--- a/lib/core/typing.mli
+++ b/lib/core/typing.mli
@@ -1,3 +1,4 @@
+open Ident
 open LambdaPC
 
 module LinearityTyping : sig
@@ -15,14 +16,14 @@ module SmtLambdaCExpr : sig
   open LambdaC
     type normal =
       NConst of int
-    | NLambda of Variable.t * Type.t * normal
+    | NLambda of Ident.t * Type.t * normal
     | NPair of normal * normal
     | Annot of neutral * Type.t
     | Neutral of neutral
     and neutral =
-      NVar of Variable.t
+      NVar of Ident.t
     | NApply of neutral * normal
-    | NCase of neutral * Variable.t * normal * Variable.t * normal
+    | NCase of neutral * Ident.t * normal * Ident.t * normal
     | NPlus of neutral * normal
     | NScale of normal * neutral
 

--- a/lib/examples.mli
+++ b/lib/examples.mli
@@ -1,3 +1,5 @@
+open Ident
+
 (* examples.mli *)
 
 (** [const r] returns a LambdaC expression representing the scalar r *)
@@ -54,31 +56,23 @@ val cnot : LambdaPC.Expr.pc
 module S2 : Scalars.SCALARS
 module Eval2 :
   sig
-    module VarEnv = LambdaC.VariableEnvironment
-    val var_env : VarEnv.t ref
-    val set_variable_environment : VarEnv.t -> unit
-    val fresh : unit -> int
     module LEval :
       sig
-        val var_env : VarEnv.t ref
-        val set_variable_environment : VarEnv.t -> unit
         val vzero : LambdaC.Type.t -> LambdaC.Val.t
         val vplus : LambdaC.Val.t -> LambdaC.Val.t -> LambdaC.Val.t
         val vscale : int -> LambdaC.Val.t -> LambdaC.Val.t
         val eval :
-          LambdaC.Val.t LambdaC.VariableMap.t ->
+          LambdaC.Val.t VariableMap.t ->
           LambdaC.Expr.t -> LambdaC.Val.t
         val symplectic_form : LambdaC.Val.t -> LambdaC.Val.t -> S2.Zd.t
       end
     module LEval' :
       sig
-        val var_env : VarEnv.t ref
-        val set_variable_environment : VarEnv.t -> unit
         val vzero : LambdaC.Type.t -> LambdaC.Val.t
         val vplus : LambdaC.Val.t -> LambdaC.Val.t -> LambdaC.Val.t
         val vscale : int -> LambdaC.Val.t -> LambdaC.Val.t
         val eval :
-          LambdaC.Val.t LambdaC.VariableMap.t ->
+          LambdaC.Val.t VariableMap.t ->
           LambdaC.Expr.t -> LambdaC.Val.t
         val symplectic_form : LambdaC.Val.t -> LambdaC.Val.t -> S2.Zd'.t
       end
@@ -90,7 +84,7 @@ module Eval2 :
     val cfg_pow : LambdaPC.Val.t -> int -> LambdaPC.Val.t
     val case_phase : int -> int -> int
     val eval :
-      LambdaC.Val.t LambdaC.VariableMap.t ->
+      LambdaC.Val.t VariableMap.t ->
       LambdaPC.Expr.t -> LambdaPC.Val.t
     val evalClosed : LambdaPC.Expr.t -> LambdaPC.Val.t
   end

--- a/lib/interface/ident.ml
+++ b/lib/interface/ident.ml
@@ -9,22 +9,28 @@ module Ident = struct
   type t =
     { text : string
     ; sym : Symbol.t
-    ; loc : Loc.t
+    ; loc : Loc.t option
     }
 
-  let mk ~text ~loc = { text; sym = Symbol.Id.intern text; loc }
+  let mk ~text ~loc = { text; sym = Symbol.Id.intern text; loc = Some loc }
   let compare x1 x2 = Symbol.Id.compare x1.sym x2.sym
   let equal x1 x2 = Symbol.Id.equal x1.sym x2.sym
   let string_of_t x = Symbol.Id.name x.sym
 
-  let fresh ?(hint = "x") (loc : Loc.t) () : t =
+  let fresh ?(hint = "x") ?loc () : t =
     let sym = Fresh.fresh ~hint () in
     { text = Symbol.Id.name sym; sym; loc }
 
 
-  let fresh_like ?hint (loc : Loc.t) (x : t) : t =
+  let fresh_like ?hint ?loc (x : t) : t =
     let hint = match hint with Some h -> h | None -> x.text in
-    fresh ~hint loc ()
+    let loc  = match loc, x.loc with Some l, _ | None, Some l -> Some l | _, _ -> None in
+    let sym = Fresh.fresh ~hint () in
+    { text = Symbol.Id.name sym; sym; loc}
+
+  let seed (x : t) : unit =
+    Symbol.Fresh.ensure_ge (x.sym + 1)
+
 end
 module VariableMap = Map.Make(Ident)
 

--- a/lib/interface/interface.ml
+++ b/lib/interface/interface.ml
@@ -1,5 +1,6 @@
 (* top-level interface for interacting with LambdaPC via the interpreter or other *)
 include LambdaPC.HOAS
+open Ident
 
 module S2 = Scalars.Scalars (Scalars.FIN2)
 module LEval2 = LambdaC.Eval(S2.Zd)
@@ -42,8 +43,10 @@ let parse_with
         if lx = "" then "end of input" else Printf.sprintf "%S" lx
       in
       raise (Parse_error (Util.loc_string_of_positions sp ep, "Parse error near " ^ near))
-  | Resolve.Error { loc; msg } ->
+  | Resolve.Error { loc=Some loc; msg } ->
       raise (Parse_error (Util.loc_string_of_positions loc.sp loc.ep, msg))
+  | Resolve.Error { loc=None; msg } ->
+      raise (Parse_error ("Undefined Location", msg))
 
 let parse (s : string) : Named_ast.LambdaPC_Surface.expr =
   let lexbuf = Lexing.from_string s in
@@ -79,9 +82,9 @@ let eval e =
 let leval e =
   print_endline (LambdaC.Expr.pretty_string_of_t e ^ "\n->*\n");
   let eval_closed = match !dim with
-             | 2 -> LEval2.eval LambdaC.VariableMap.empty
-             | 3 -> LEval3.eval LambdaC.VariableMap.empty
-             | 4 -> LEval4.eval LambdaC.VariableMap.empty
+             | 2 -> LEval2.eval VariableMap.empty
+             | 3 -> LEval3.eval VariableMap.empty
+             | 4 -> LEval4.eval VariableMap.empty
              | d -> failwith @@ "Please add evaluation module for dimension " ^ string_of_int d ^ "\n"
   in
   let result = eval_closed e in

--- a/lib/interface/resolve.ml
+++ b/lib/interface/resolve.ml
@@ -1,7 +1,7 @@
 open Named_ast
 open Ident
 
-exception Error of { loc : Loc.t; msg : string }
+exception Error of { loc : Loc.t option; msg : string }
 
 type env = (Symbol.t * Symbol.t) list
 

--- a/lib/lambdaC/lambdaC.ml
+++ b/lib/lambdaC/lambdaC.ml
@@ -142,44 +142,68 @@ module Expr = struct
         update_env a'
       | Apply (a1, a2) -> update_env a1; update_env a2
 
-    (* alpha equivalence *)
-    (* Take as input two expressions. Returns true iff they are syntactically equal (including free variables, possibly not including type or usage annotations) up to renaming their bound variables. To check if two binders are equal e.g. (lambda x1.a1) and (lambda x2.a2), the function will create a fresh variable y from env and rename both x1 and x2 to y.
-      Requires: fresh env will always return a variable that does not occur in either a1 or a2
-    *)
-    let rec alpha_equiv' a1 a2 =
+
+    let bind_binders env_lr env_rl (xl : Ident.t) (xr : Ident.t) =
+      let l = VariableMap.find_opt xl env_lr in
+      let r = VariableMap.find_opt xr env_rl in
+      match l, r with
+      | None, None ->
+          Some (
+            VariableMap.add xl xr env_lr,
+            VariableMap.add xr xl env_rl
+          )
+      | Some xr', Some xl' when Ident.equal xr xr' && Ident.equal xl xl' ->
+          Some (env_lr, env_rl)
+      | _, _ ->
+          None
+
+    (* alpha equivalence with explicit binder correspondence; does not allocate fresh ids *)
+    let rec alpha_equiv' env_lr env_rl a1 a2 =
       match a1, a2 with
-      | Var x1, Var x2 -> x1 = x2
-      | Let(a1,x1,a1'), Let(a2,x2,a2') ->
-        let x = Ident.fresh_like x1 in
-        alpha_equiv' a1 a2
-          && alpha_equiv' (rename_var x1 x a1') (rename_var x2 x a2')
-      | Zero tp1, Zero tp2 -> tp1 = tp2
-      | Annot(a1', tp1), Annot(a2', tp2) -> tp1 = tp2 && alpha_equiv' a1' a2'
-      | Annot(a1', _), _ -> alpha_equiv' a1' a2
-      | _, Annot(a2', _) -> alpha_equiv' a1 a2'
-      | Plus (a11,a12), Plus(a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
-      | Const v1, Const v2 -> v1 = v2
-      | Scale (a11,a12), Scale (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
-      | Pair (a11,a12), Pair (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
-      | Case (a1',x11,a11,x12,a12), Case(a2',x21,a21,x22,a22) ->
-        let x = Ident.fresh_like x11 in
-        alpha_equiv' a1' a2'
-        && alpha_equiv' (rename_var x11 x a11) (rename_var x21 x a21)
-        && alpha_equiv' (rename_var x12 x a12) (rename_var x22 x a22)
-      | Lambda (x1, tp1, a1), Lambda (x2, tp2, a2) ->
-        let x = Ident.fresh_like x1 in
-        tp1 = tp2 && alpha_equiv' (rename_var x1 x a1) (rename_var x2 x a2)
-      | Apply (a11,a12), Apply (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
+      | Var x1, Var x2 ->
+        (match VariableMap.find_opt x1 env_lr, VariableMap.find_opt x2 env_rl with
+         | Some x2', Some x1' -> Ident.equal x2 x2' && Ident.equal x1 x1'
+         | None, None -> Ident.equal x1 x2
+         | _, _ -> false)
+      | Let (a11, x1, a12), Let (a21, x2, a22) ->
+        alpha_equiv' env_lr env_rl a11 a21
+        &&
+        (match bind_binders env_lr env_rl x1 x2 with
+         | Some (env_lr', env_rl') -> alpha_equiv' env_lr' env_rl' a12 a22
+         | None -> false)
+      | Zero tp1, Zero tp2 ->
+        tp1 = tp2
+      | Annot (a1', tp1), Annot (a2', tp2) ->
+        tp1 = tp2 && alpha_equiv' env_lr env_rl a1' a2'
+      | Annot (a1', _), _ ->
+        alpha_equiv' env_lr env_rl a1' a2
+      | _, Annot (a2', _) ->
+        alpha_equiv' env_lr env_rl a1 a2'
+      | Plus (a11, a12), Plus (a21, a22)
+      | Scale (a11, a12), Scale (a21, a22)
+      | Pair (a11, a12), Pair (a21, a22)
+      | Apply (a11, a12), Apply (a21, a22) ->
+        alpha_equiv' env_lr env_rl a11 a21 && alpha_equiv' env_lr env_rl a12 a22
+      | Const v1, Const v2 ->
+        v1 = v2
+      | Case (scrut1, x11, a11, x12, a12), Case (scrut2, x21, a21, x22, a22) ->
+        alpha_equiv' env_lr env_rl scrut1 scrut2
+        &&
+        (match bind_binders env_lr env_rl x11 x21, bind_binders env_lr env_rl x12 x22 with
+         | Some (env_lr1, env_rl1), Some (env_lr2, env_rl2) ->
+           alpha_equiv' env_lr1 env_rl1 a11 a21
+           && alpha_equiv' env_lr2 env_rl2 a12 a22
+         | _, _ -> false)
+      | Lambda (x1, tp1, body1), Lambda (x2, tp2, body2) ->
+        tp1 = tp2
+        &&
+        (match bind_binders env_lr env_rl x1 x2 with
+         | Some (env_lr', env_rl') -> alpha_equiv' env_lr' env_rl' body1 body2
+         | None -> false)
       | _, _ -> false
 
-    let alpha_equiv = alpha_equiv'
-    (*
     let alpha_equiv a1 a2 =
-      let env = VariableEnvironment.init in
-      update_env env a1;
-      update_env env a2;
-      alpha_equiv' env a1 a2
-    *)
+      alpha_equiv' VariableMap.empty VariableMap.empty a1 a2
 
   end
 

--- a/lib/lambdaC/lambdaC.ml
+++ b/lib/lambdaC/lambdaC.ml
@@ -1,4 +1,5 @@
 open Scalars
+open Ident
 
 module Type = struct
 
@@ -15,99 +16,25 @@ module Type = struct
 
 end
 
-module Variable = struct
-  type t = int
-  let compare = Int.compare
-end
-module VariableMap = Map.Make(Variable)
-
-module VariableEnvironment = struct
-  type t = Variable.t ref
-  
-  let init : t = {contents = 0}
-  let fresh (x : t) : Variable.t =
-    let y = !x in
-    x := y + 1;
-    y
-
-  (* Record the existance of the variable x *)
-  let update (x : Variable.t) (env : t) : unit =
-    env := max (x+1) !env
-end 
-
-
-module VariableSet = struct
-  module M = Set.Make(Variable)
-  include M
-  (*
-  let string_of_t u = List.fold_left (fun str x -> str ^ string_of_int x) "{" (to_list u)  ^ "}"
-
-  let rename from to_ u = M.map (fun z -> if z = from then to_ else z) u
-  *)
-
-  let rec exists_usage_subset (u : t) (f : t -> bool) : bool =
-    (* want to check if:
-        exists u0, u0 subset u && f u0 }
-      if u is empty (u=0), just check if f(0)
-      if u is not empty, then pick some x in u:
-        u = (u-{x}) U {x}}
-      then
-        u0 subset u
-        <->
-        u0 subset (u-{x})
-        ||
-        (x \in u0 && (u0-{x} subset (u - {x}))
-
-      so 
-        exists u0, u0 subset u && f u0
-        <->
-
-        exists u0,
-          (u0 subset (u-{x}) && f u0)
-        ||
-        exists u0,
-          (x \in u0 && (u0 - {x} subset (u - {x})) && f u0)
-
-        <->
-
-        exists u0,
-          (u0 subset (u-{x}) && f u0)
-        ||
-        exists u0',
-          (u0' subset (u - {x})) && f ({x} union u0'))
-
-        <->
-
-        exists u0,
-          u0 subset (u - {x})
-          && f u0 || f ({x} union u0')
-    *)
-    if M.is_empty u then f u
-    else
-      let x = M.choose u in
-      exists_usage_subset (M.remove x u)
-        (fun u0 -> f u0 || f (M.add x u0))
-end
-
 module Expr = struct
 
   type t =
-      Var of Variable.t
-    | Let of t * Variable.t * t
+      Var of Ident.t
+    | Let of t * Ident.t * t
     | Zero of Type.t
     | Annot of t * Type.t
     | Plus of t * t
     | Const of int
     | Scale of t * t
     | Pair of t * t
-    | Case of t * Variable.t * t * Variable.t * t
-    | Lambda of Variable.t * Type.t * t
+    | Case of t * Ident.t * t * Ident.t * t
+    | Lambda of Ident.t * Type.t * t
     | Apply of t * t
 
     let rec string_of_t a =
       match a with
-      | Var x -> "Var(" ^ string_of_int x ^ ")"
-      | Let (a1,x,a2) -> "Let(" ^ string_of_t a1 ^ ", " ^ string_of_int x ^ ", " ^ string_of_t a2 ^ ")"
+      | Var x -> "Var(" ^ Ident.string_of_t x ^ ")"
+      | Let (a1,x,a2) -> "Let(" ^ string_of_t a1 ^ ", " ^ Ident.string_of_t x ^ ", " ^ string_of_t a2 ^ ")"
       | Zero tp -> "Zero(" ^ Type.string_of_t tp ^ ")"
       | Annot (a, tp) -> "Annot( " ^ string_of_t a ^ ", " ^ Type.string_of_t tp ^ ")"
       | Plus (a1, a2) -> "Plus(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
@@ -115,16 +42,16 @@ module Expr = struct
       | Scale (a1, a2) -> "Scale(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
       | Pair (a1, a2) -> "Pair(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
       | Case (scrut, x1, a1, x2, a2) ->
-          "Case(" ^ string_of_t scrut ^ ", " ^ string_of_int x1 ^ ", " ^ string_of_t a1 ^ ", " ^ string_of_int x2 ^ ", " ^ string_of_t a2 ^ ")"
+          "Case(" ^ string_of_t scrut ^ ", " ^ Ident.string_of_t x1 ^ ", " ^ string_of_t a1 ^ ", " ^ Ident.string_of_t x2 ^ ", " ^ string_of_t a2 ^ ")"
       | Lambda (x, tp, body) ->
-          "Lambda(" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ string_of_t body ^ ")"
+          "Lambda(" ^ Ident.string_of_t x ^ ":" ^ Type.string_of_t tp ^ ". " ^ string_of_t body ^ ")"
       | Apply (a1, a2) -> "Apply(" ^ string_of_t a1 ^ ", " ^ string_of_t a2 ^ ")"
 
     
     let rec pretty_string_of_t a =
       match a with
-      | Var x -> "x" ^ string_of_int x
-      | Let (a1,x,a2) -> "let x" ^ string_of_int x ^ " = " ^ pretty_string_of_t a1 ^ " in " ^ pretty_string_of_t a2
+      | Var x -> "x" ^ Ident.string_of_t x
+      | Let (a1,x,a2) -> "let x" ^ Ident.string_of_t x ^ " = " ^ pretty_string_of_t a1 ^ " in " ^ pretty_string_of_t a2
       | Zero tp -> "0{" ^ Type.string_of_t tp ^ "}"
       | Annot (a, tp) -> "(" ^ pretty_string_of_t a ^ " : " ^ Type.string_of_t tp ^ ")"
       | Plus (a1, a2) -> pretty_string_of_t a1 ^ " + " ^ pretty_string_of_t a2
@@ -137,15 +64,15 @@ module Expr = struct
       | Pair (a1, a2) -> "[" ^ pretty_string_of_t a1 ^ ", " ^ pretty_string_of_t a2 ^ "]"
       | Case (scrut, x1, a1, x2, a2) ->
           "case " ^ pretty_string_of_t scrut
-          ^ " of { x" ^ string_of_int x1 ^ " -> " ^ pretty_string_of_t a1 
-          ^ " | x" ^ string_of_int x2 ^ " -> " ^ pretty_string_of_t a2 ^ "}"
+          ^ " of { x" ^ Ident.string_of_t x1 ^ " -> " ^ pretty_string_of_t a1 
+          ^ " | x" ^ Ident.string_of_t x2 ^ " -> " ^ pretty_string_of_t a2 ^ "}"
       | Lambda (x, tp, body) ->
-          "lambda x" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ pretty_string_of_t body
+          "lambda x" ^ Ident.string_of_t x ^ ":" ^ Type.string_of_t tp ^ ". " ^ pretty_string_of_t body
       | Apply (a1, a2) -> pretty_string_of_t a1 ^ " @ " ^ pretty_string_of_t a2
 
 
     (* NOT epxlicitly capture-avoiding, assumes NO reuse of variables *)
-    let rec subst (from : Variable.t) (to_ : t) (a : t) : t =
+    let rec subst (from : Ident.t) (to_ : t) (a : t) : t =
       match a with
       | Var x -> if x = from then to_ else Var x
       | Let (a1,x,a2) ->
@@ -189,75 +116,74 @@ module Expr = struct
       | Apply (a1,a2) -> 
         Apply (map f a1, map f a2)
 
+
     (* Update env so its next fresh variable is not in a *)
-    let rec update_env env a =
+    let rec update_env a =
       match a with
-      | Var x -> VariableEnvironment.update x env
+      | Var x -> Ident.seed x
       | Let(a1,x,a2) ->
-        update_env env a1;
-        VariableEnvironment.update x env;
-        update_env env a2
+        Ident.seed x;
+        update_env a1;
+        update_env a2
       | Zero _ -> ()
-      | Annot (a', _) -> update_env env a'
-      | Plus (a1, a2) -> update_env env a1; update_env env a2
+      | Annot (a', _) -> update_env a'
+      | Plus (a1, a2) -> update_env a1; update_env a2
       | Const _ -> ()
-      | Scale (a1, a2) -> update_env env a1; update_env env a2
-      | Pair (a1, a2) -> update_env env a1; update_env env a2
+      | Scale (a1, a2) -> update_env a1; update_env a2
+      | Pair (a1, a2) -> update_env a1; update_env a2
       | Case (a', x1, a1', x2, a2') ->
-        update_env env a';
-        VariableEnvironment.update x1 env;
-        VariableEnvironment.update x2 env;
-        update_env env a1';
-        update_env env a2'
+        update_env a';
+        Ident.seed x1;
+        Ident.seed x2;
+        update_env a1';
+        update_env a2'
       | Lambda (x,_,a') ->
-        VariableEnvironment.update x env;
-        update_env env a'
-      | Apply (a1, a2) -> update_env env a1; update_env env a2
+        Ident.seed x;
+        update_env a'
+      | Apply (a1, a2) -> update_env a1; update_env a2
 
     (* alpha equivalence *)
     (* Take as input two expressions. Returns true iff they are syntactically equal (including free variables, possibly not including type or usage annotations) up to renaming their bound variables. To check if two binders are equal e.g. (lambda x1.a1) and (lambda x2.a2), the function will create a fresh variable y from env and rename both x1 and x2 to y.
       Requires: fresh env will always return a variable that does not occur in either a1 or a2
     *)
-    let rec alpha_equiv' (env : VariableEnvironment.t) a1 a2 =
+    let rec alpha_equiv' a1 a2 =
       match a1, a2 with
       | Var x1, Var x2 -> x1 = x2
       | Let(a1,x1,a1'), Let(a2,x2,a2') ->
-        let x = VariableEnvironment.fresh env in
-        alpha_equiv' env a1 a2
-          && alpha_equiv' env (rename_var x1 x a1') (rename_var x2 x a2')
+        let x = Ident.fresh_like x1 in
+        alpha_equiv' a1 a2
+          && alpha_equiv' (rename_var x1 x a1') (rename_var x2 x a2')
       | Zero tp1, Zero tp2 -> tp1 = tp2
-      | Annot(a1', tp1), Annot(a2', tp2) -> tp1 = tp2 && alpha_equiv' env a1' a2'
-      | Annot(a1', _), _ -> alpha_equiv' env a1' a2
-      | _, Annot(a2', _) -> alpha_equiv' env a1 a2'
-      | Plus (a11,a12), Plus(a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
+      | Annot(a1', tp1), Annot(a2', tp2) -> tp1 = tp2 && alpha_equiv' a1' a2'
+      | Annot(a1', _), _ -> alpha_equiv' a1' a2
+      | _, Annot(a2', _) -> alpha_equiv' a1 a2'
+      | Plus (a11,a12), Plus(a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
       | Const v1, Const v2 -> v1 = v2
-      | Scale (a11,a12), Scale (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
-      | Pair (a11,a12), Pair (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
+      | Scale (a11,a12), Scale (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
+      | Pair (a11,a12), Pair (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
       | Case (a1',x11,a11,x12,a12), Case(a2',x21,a21,x22,a22) ->
-        let x = VariableEnvironment.fresh env in
-        alpha_equiv' env a1' a2'
-        && alpha_equiv' env (rename_var x11 x a11) (rename_var x21 x a21)
-        && alpha_equiv' env (rename_var x12 x a12) (rename_var x22 x a22)
+        let x = Ident.fresh_like x11 in
+        alpha_equiv' a1' a2'
+        && alpha_equiv' (rename_var x11 x a11) (rename_var x21 x a21)
+        && alpha_equiv' (rename_var x12 x a12) (rename_var x22 x a22)
       | Lambda (x1, tp1, a1), Lambda (x2, tp2, a2) ->
-        let x = VariableEnvironment.fresh env in
-        tp1 = tp2 && alpha_equiv' env (rename_var x1 x a1) (rename_var x2 x a2)
-      | Apply (a11,a12), Apply (a21,a22) -> alpha_equiv' env a11 a21 && alpha_equiv' env a12 a22
+        let x = Ident.fresh_like x1 in
+        tp1 = tp2 && alpha_equiv' (rename_var x1 x a1) (rename_var x2 x a2)
+      | Apply (a11,a12), Apply (a21,a22) -> alpha_equiv' a11 a21 && alpha_equiv' a12 a22
       | _, _ -> false
 
+    let alpha_equiv = alpha_equiv'
+    (*
     let alpha_equiv a1 a2 =
       let env = VariableEnvironment.init in
       update_env env a1;
       update_env env a2;
       alpha_equiv' env a1 a2
+    *)
 
   end
 
 module HOAS = struct
-  let var_env : VariableEnvironment.t ref = {contents = VariableEnvironment.init}
-  let set_variable_environment (env : VariableEnvironment.t) = var_env := env
-  let fresh () : Variable.t = VariableEnvironment.fresh !var_env
-
-  let update_env (a : Expr.t) = Expr.update_env !var_env a
 
   let var x = Expr.Var x
   let zero tp = Expr.Zero tp
@@ -265,12 +191,12 @@ module HOAS = struct
   let const x = Expr.Const x
   let ( * ) a1 a2 = Expr.Scale (a1,a2)
   let case a fx fz =
-      let x = fresh() in
-      let z = fresh() in
+      let x = Ident.fresh() in
+      let z = Ident.fresh() in
       Expr.Case(a, x, fx (var x), z, fz (var z))
   
   let lambda tp (f : Expr.t -> Expr.t) =
-      let x = fresh() in
+      let x = Ident.fresh() in
       Expr.Lambda (x, tp, f (var x))
 
   let (@) a1 a2 = Expr.Apply (a1, a2)
@@ -283,14 +209,14 @@ module Val = struct
     type t =
       | Const of int
       | Pair of t * t
-      | Lambda of Variable.t * Type.t * Expr.t
+      | Lambda of Ident.t * Type.t * Expr.t
 
     let rec string_of_t v =
           match v with
           | Const c -> string_of_int c
           | Pair (v1, v2) -> "(" ^ string_of_t v1 ^ ", " ^ string_of_t v2 ^ ")"
           | Lambda (x, tp, a) ->
-              "Lambda(" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.string_of_t a ^ ")"
+              "Lambda(" ^ Ident.string_of_t x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.string_of_t a ^ ")"
 
 
     let rec pretty_string_of_t v =
@@ -302,7 +228,7 @@ module Val = struct
           | Pair (Const 1, Const 1) -> "Y"
           | Pair (v1, v2) -> "(" ^ pretty_string_of_t v1 ^ ", " ^ pretty_string_of_t v2 ^ ")"
           | Lambda (x, tp, a) ->
-              "lambda x" ^ string_of_int x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.pretty_string_of_t a
+              "lambda x" ^ Ident.string_of_t x ^ ":" ^ Type.string_of_t tp ^ ". " ^ Expr.pretty_string_of_t a
 
     let rec expr_of_t v =
       match v with
@@ -322,9 +248,6 @@ module Val = struct
   end
 
 module Eval (Zd : Z_SIG) = struct
-  let var_env : VariableEnvironment.t ref = {contents = VariableEnvironment.init}
-  let set_variable_environment (env : VariableEnvironment.t) = var_env := env
-  let fresh () : Variable.t = VariableEnvironment.fresh !var_env
 
   let rec vzero (ltp : Type.t) =
     match ltp with
@@ -334,7 +257,7 @@ module Eval (Zd : Z_SIG) = struct
         let v2 = vzero ltp2 in
         Val.Pair (v1, v2)
     | Arrow (ltp1, ltp2) ->
-        let x = fresh() in
+        let x = Ident.fresh() in
         let v = vzero ltp2 in
         Val.Lambda (x, ltp1, Val.expr_of_t v)
 
@@ -346,7 +269,7 @@ module Eval (Zd : Z_SIG) = struct
       Val.Pair (vplus a1 a2, vplus b1 b2)
     | Val.Lambda (x1, tp1, a1), Val.Lambda (x2, tp2, a2) ->
         if tp1 = tp2 then
-            let fresh_x = fresh() in
+            let fresh_x = Ident.fresh() in
             let a1' = Expr.rename_var x1 fresh_x a1 in
             let a2' = Expr.rename_var x2 fresh_x a2 in
             Val.Lambda (fresh_x, tp1, Expr.Plus (a1', a2'))
@@ -411,7 +334,7 @@ module Eval (Zd : Z_SIG) = struct
 end
 
 module TypeInformation = struct
-  type usage_relation = VariableSet.t -> VariableSet.t -> bool
+  type usage_relation = IdentSet.t -> IdentSet.t -> bool
 
   type ('tp, 'expr) t = {
     usage : usage_relation;
@@ -438,10 +361,10 @@ module TypeInformation = struct
     (*print_string _msg;*)
     ()
 
-  let type_of_var (gamma : 'a VariableMap.t) (x : Variable.t) : 'a =
+  let type_of_var (gamma : 'a VariableMap.t) (x : Ident.t) : 'a =
     match VariableMap.find_opt x gamma with
     | None ->
-      let msg = "Variable " ^ string_of_int x ^ " not found in the typing context" in
+      let msg = "Variable " ^ Ident.string_of_t x ^ " not found in the typing context" in
       terr msg
     | Some tp -> tp
 
@@ -453,34 +376,34 @@ module TypeInformation = struct
 
   let var_usage x : usage_relation =
     fun u1 u2 ->
-      VariableSet.mem x u1
-      && VariableSet.equal u2 (VariableSet.remove x u1)
+      IdentSet.mem x u1
+      && IdentSet.equal u2 (IdentSet.remove x u1)
   let same_usage info1 info2 : usage_relation =
     fun u1 u2 -> info1.usage u1 u2 && info2.usage u1 u2
   let disjoint_usage info1 info2 : usage_relation =
     fun u_in u_out ->
-      VariableSet.exists_usage_subset u_in (fun u_mid ->
+      IdentSet.exists_usage_subset u_in (fun u_mid ->
         info1.usage u_in u_mid
         && info2.usage u_mid u_out
         )
   let disjoint_usage_with info1 x info2 : usage_relation =
     fun u_in u_out ->
-      VariableSet.exists_usage_subset u_in (fun u_mid ->
-        not (VariableSet.mem x u_in)
+      IdentSet.exists_usage_subset u_in (fun u_mid ->
+        not (IdentSet.mem x u_in)
         && info1.usage u_in u_mid
-        && info2.usage (VariableSet.add x u_mid) u_out
-        && not (VariableSet.mem x u_out)
+        && info2.usage (IdentSet.add x u_mid) u_out
+        && not (IdentSet.mem x u_out)
       )
   let disjoint_usage_branch info0 x1 info1 x2 info2 : usage_relation =
     fun u_in u_out ->
-      VariableSet.exists_usage_subset u_in (fun u_mid ->
+      IdentSet.exists_usage_subset u_in (fun u_mid ->
         (* variables x1 and x2 should not appear in u_in or u_out at all *)
-        (VariableSet.is_empty @@ VariableSet.inter
-          (VariableSet.union u_in u_out)
-          (VariableSet.of_list [x1;x2]))
+        (IdentSet.is_empty @@ IdentSet.inter
+          (IdentSet.union u_in u_out)
+          (IdentSet.of_list [x1;x2]))
         && info0.usage u_in u_mid
-        && info1.usage (VariableSet.add x1 u_mid) u_out
-        && info2.usage (VariableSet.add x2 u_mid) u_out
+        && info1.usage (IdentSet.add x1 u_mid) u_out
+        && info2.usage (IdentSet.add x2 u_mid) u_out
         )
 end
 
@@ -524,7 +447,7 @@ module Typing = struct
       {
         expr = Zero tp;
         tp = tp;
-        usage = fun u1 u2 -> VariableSet.subset u2 u1
+        usage = fun u1 u2 -> IdentSet.subset u2 u1
       }
 
     | Annot (a',alpha) ->
@@ -550,7 +473,7 @@ module Typing = struct
       {
         expr = Const r;
         tp = Unit;
-        usage = VariableSet.equal
+        usage = IdentSet.equal
       }
 
     | Scale (a1,a2) ->
@@ -593,8 +516,8 @@ module Typing = struct
         expr = Lambda (x, alpha, info'.expr);
         tp = Arrow(alpha,info'.tp);
         usage = fun u1 u2 ->
-          not VariableSet.(mem x (union u1 u2))
-          && info'.usage (VariableSet.add x u1) u2
+          not IdentSet.(mem x (union u1 u2))
+          && info'.usage (IdentSet.add x u1) u2
       }
 
     | Apply (a1,a2) ->
@@ -611,7 +534,7 @@ module Typing = struct
   let typecheck a =
     let info = typecheck' VariableMap.empty a in
     (* linearity check implies info.usage(0,0) *)
-    match info.usage VariableSet.empty VariableSet.empty with
+    match info.usage IdentSet.empty IdentSet.empty with
     | true -> info
     | false ->
       terr @@ "Linearity check failed in the usage relation:\n" ^ string_of_info info

--- a/lib/lambdaC/lambdaC.mli
+++ b/lib/lambdaC/lambdaC.mli
@@ -1,57 +1,39 @@
 open Scalars
+open Ident
 
 module Type : sig
   type t = Unit | Sum of t * t | Arrow of t * t
   val string_of_t : t -> string
 end
 
-module Variable : Map.OrderedType with type t = int
-module VariableMap : Map.S with type key = Variable.t
-module VariableSet : sig
-  include Set.S with type elt = Variable.t
-  val exists_usage_subset : t -> (t -> bool) -> bool
-end
-
-
-module VariableEnvironment : sig
-  type t
-  val init : t
-  val fresh : t -> Variable.t
-  val update : Variable.t -> t -> unit
-end 
-
 module Expr : sig
   type t =
-      Var of Variable.t
-    | Let of t * Variable.t * t
+      Var of Ident.t
+    | Let of t * Ident.t * t
     | Zero of Type.t
     | Annot of t * Type.t
     | Plus of t * t
     | Const of int
     | Scale of t * t
     | Pair of t * t
-    | Case of t * Variable.t * t * Variable.t * t
-    | Lambda of Variable.t * Type.t * t
+    | Case of t * Ident.t * t * Ident.t * t
+    | Lambda of Ident.t * Type.t * t
     | Apply of t * t
 
   val string_of_t : t -> string
   val pretty_string_of_t : t -> string
-  val subst : Variable.t -> t -> t -> t
-  val rename_var : Variable.t -> Variable.t -> t -> t
+  val subst : Ident.t -> t -> t -> t
+  val rename_var : Ident.t -> Ident.t -> t -> t
   val map : (int -> int) -> t -> t
-  val update_env : VariableEnvironment.t -> t -> unit
+  val update_env : t -> unit
   val alpha_equiv : t -> t -> bool
 end
 
 
 
 module HOAS : sig
-  val var_env : VariableEnvironment.t ref
-  val set_variable_environment : VariableEnvironment.t -> unit
-  val fresh : unit -> Variable.t
-  val update_env : Expr.t -> unit
 
-  val var : Variable.t -> Expr.t
+  val var : Ident.t -> Expr.t
   val zero : Type.t -> Expr.t
   val (+) : Expr.t -> Expr.t -> Expr.t
   val const : int -> Expr.t
@@ -69,7 +51,7 @@ module Val : sig
   type t =
     | Const of int
     | Pair of t * t
-    | Lambda of Variable.t * Type.t * Expr.t
+    | Lambda of Ident.t * Type.t * Expr.t
   val string_of_t : t -> string
   val pretty_string_of_t : t -> string
   val expr_of_t : t -> Expr.t
@@ -79,8 +61,6 @@ end
 
 
 module Eval : functor (Zd : Z_SIG) -> sig
-  val var_env : VariableEnvironment.t ref
-  val set_variable_environment : VariableEnvironment.t -> unit
 
   val vzero  : Type.t -> Val.t
   val vplus  : Val.t -> Val.t -> Val.t
@@ -92,7 +72,7 @@ module Eval : functor (Zd : Z_SIG) -> sig
 end
 
 module TypeInformation : sig
-  type usage_relation = VariableSet.t -> VariableSet.t -> bool
+  type usage_relation = IdentSet.t -> IdentSet.t -> bool
 
   type ('tp, 'expr) t = {
     usage : usage_relation;
@@ -106,14 +86,14 @@ module TypeInformation : sig
   exception TypeError
   val terr : string -> 'a
   val debug : string -> unit
-  val type_of_var : 'a VariableMap.t -> Variable.t -> 'a
+  val type_of_var : 'a VariableMap.t -> Ident.t -> 'a
   val assert_type : ('a -> string) -> 'a -> 'a -> unit
 
-  val var_usage : Variable.t -> usage_relation
+  val var_usage : Ident.t -> usage_relation
   val same_usage : ('tp1,'expr1) t -> ('tp2,'expr2) t -> usage_relation
   val disjoint_usage : ('tp1,'expr1) t -> ('tp2,'expr2) t -> usage_relation
-  val disjoint_usage_with : ('tp1,'expr1) t -> Variable.t -> ('tp2,'expr2) t -> usage_relation
-  val disjoint_usage_branch : ('tp0,'expr0) t -> Variable.t -> ('tp1,'expr1) t -> Variable.t -> ('tp2,'expr2) t -> usage_relation
+  val disjoint_usage_with : ('tp1,'expr1) t -> Ident.t -> ('tp2,'expr2) t -> usage_relation
+  val disjoint_usage_branch : ('tp0,'expr0) t -> Ident.t -> ('tp1,'expr1) t -> Ident.t -> ('tp2,'expr2) t -> usage_relation
 end
 
 

--- a/lib/lambdaPC/lambdaPC.ml
+++ b/lib/lambdaPC/lambdaPC.ml
@@ -1,4 +1,5 @@
 open Scalars
+open Ident
 
 module Type = struct
 
@@ -30,15 +31,12 @@ module Type = struct
     | PTensor (tp1, tp2) -> "(" ^ string_of_t tp1 ^ ") ** (" ^ string_of_t tp2 ^ ")"
 end
 
-module Variable = LambdaC.Variable
-module VariableMap = LambdaC.VariableMap
-
 module Expr = struct
 
   type t =
-    | Var   of Variable.t
+    | Var   of Ident.t
     | Annot of t * Type.t
-    | Let   of t * Variable.t * t
+    | Let   of t * Ident.t * t
     | LExpr of LambdaC.Expr.t
     | Phase of LambdaC.Expr.t * t
     | Prod  of t * t
@@ -46,21 +44,21 @@ module Expr = struct
     | CasePauli of t * t * t
     | In1   of t * Type.t
     | In2   of Type.t * t
-    | CasePTensor of t * Variable.t * t * Variable.t * t
+    | CasePTensor of t * Ident.t * t * Ident.t * t
     | Apply of pc * t
     | Force of p
 
-  and pc = Lam of (Variable.t * Type.t * t)
+  and pc = Lam of (Ident.t * Type.t * t)
 
   and p = Suspend of t
   
   (*val string_of_t : t -> string*)
   let rec string_of_t e = 
     match e with
-      | Var x -> "Var(" ^ string_of_int x ^ ")"
+      | Var x -> "Var(" ^ Ident.string_of_t x ^ ")"
       | Annot (t',tau') ->
         "Annot(" ^ string_of_t t' ^ ", " ^ Type.string_of_t tau' ^ ")"
-      | Let (e1, x, e2) -> "Let(" ^ string_of_t e1 ^ ", " ^ string_of_int x ^ ", " ^ string_of_t e2 ^ ")"
+      | Let (e1, x, e2) -> "Let(" ^ string_of_t e1 ^ ", " ^ Ident.string_of_t x ^ ", " ^ string_of_t e2 ^ ")"
       | LExpr le -> "LExpr(" ^ LambdaC.Expr.string_of_t le ^ ")"
       | Phase (a, t) -> "Phase(" ^ LambdaC.Expr.string_of_t a ^ ", " ^ string_of_t t ^ ")"
       | Prod (t1, t2) -> "Prod(" ^ string_of_t t1 ^ ", " ^ string_of_t t2 ^ ")"
@@ -69,21 +67,21 @@ module Expr = struct
       | In1 (t,_tp) -> "In1(" ^ string_of_t t ^ ")"
       | In2 (_,t) -> "In2(" ^ string_of_t t ^ ")"
       | CasePTensor (e, x1, t1, x2, t2) ->
-        "CasePTensor(" ^ string_of_t e ^ ", " ^ string_of_int x1 ^ ", " ^ string_of_t t1 ^ ", " ^ string_of_int x2 ^ ", " ^ string_of_t t2 ^ ")"
+        "CasePTensor(" ^ string_of_t e ^ ", " ^ Ident.string_of_t x1 ^ ", " ^ string_of_t t1 ^ ", " ^ Ident.string_of_t x2 ^ ", " ^ string_of_t t2 ^ ")"
 
       | Apply (f, e) -> string_of_pc f ^ " @ " ^ string_of_t e
       | Force e' -> string_of_p e'
   and string_of_pc f = match f with
-      | Lam (x, tp, e) -> "lambda " ^ string_of_int x ^ " : " ^ Type.string_of_t tp ^ ". " ^ string_of_t e
+      | Lam (x, tp, e) -> "lambda " ^ Ident.string_of_t x ^ " : " ^ Type.string_of_t tp ^ ". " ^ string_of_t e
   and string_of_p e = match e with
       | Suspend e' -> string_of_t e'
 
 let rec pretty_string_of_t e = 
     match e with
-      | Var x -> "x" ^ string_of_int x
+      | Var x -> "x" ^ Ident.string_of_t x
       | Annot (e',tau') ->
         "(" ^ pretty_string_of_t e' ^ " : " ^ Type.string_of_t tau' ^ ")"
-      | Let (e1, x, e2) -> "let " ^ string_of_int x ^ " = " ^ pretty_string_of_t e1 ^ " in " ^ pretty_string_of_t e2
+      | Let (e1, x, e2) -> "let " ^ Ident.string_of_t x ^ " = " ^ pretty_string_of_t e1 ^ " in " ^ pretty_string_of_t e2
       | LExpr le ->
         LambdaC.Expr.pretty_string_of_t le
       | Phase (a, t) -> "<" ^ LambdaC.Expr.pretty_string_of_t a ^ "> " ^ pretty_string_of_t t
@@ -94,17 +92,17 @@ let rec pretty_string_of_t e =
       | In2 (_,t) -> "in2(" ^ pretty_string_of_t t ^ ")"
       | CasePTensor (e, x1, t1, x2, t2) ->
         "case " ^ pretty_string_of_t e
-                ^ " of { in1 x" ^  string_of_int x1 ^ " -> " ^ pretty_string_of_t t1 
-                ^ " | in2 x" ^ string_of_int x2 ^ " -> " ^ pretty_string_of_t t2 ^ "}"
+                ^ " of { in1 x" ^  Ident.string_of_t x1 ^ " -> " ^ pretty_string_of_t t1 
+                ^ " | in2 x" ^ Ident.string_of_t x2 ^ " -> " ^ pretty_string_of_t t2 ^ "}"
 
       | Apply (f, e) -> "(" ^ pretty_string_of_pc f ^ ") @ (" ^ pretty_string_of_t e ^ ")"
       | Force e' -> pretty_string_of_p e'
   and pretty_string_of_pc f = match f with
-      | Lam (x, tp, e) -> "lambda x" ^ string_of_int x ^ " : " ^ Type.string_of_t tp ^ ". " ^ pretty_string_of_t e
+      | Lam (x, tp, e) -> "lambda x" ^ Ident.string_of_t x ^ " : " ^ Type.string_of_t tp ^ ". " ^ pretty_string_of_t e
   and pretty_string_of_p e = match e with
       | Suspend e' -> pretty_string_of_t e'
 
-  let rec rename_var (from : Variable.t) (to_ : Variable.t) e =
+  let rec rename_var (from : Ident.t) (to_ : Ident.t) e =
       match e with
       | Var x ->
           if x = from then Var to_ else Var x
@@ -153,11 +151,9 @@ end
 
 
 module HOAS = struct
-  let fresh = LambdaC.HOAS.fresh
-
-  let var (x : Variable.t) = Expr.Var x
+  let var (x : Ident.t) = Expr.Var x
   let letin e f =
-    let x = fresh() in
+    let x = Ident.fresh() in
     Expr.Let (e, x, f (var x))
   let vec a = Expr.LExpr a
   let phase a e = Expr.Phase(a, e)
@@ -167,12 +163,12 @@ module HOAS = struct
   let in1 e tp2 = Expr.In1 (e,tp2)
   let in2 tp1 e = Expr.In2 (tp1, e)
   let caseof e b1 b2 =
-    let x1 = fresh() in
-    let x2 = fresh() in
+    let x1 = Ident.fresh() in
+    let x2 = Ident.fresh() in
     Expr.CasePTensor(e, x1, b1 (var x1), x2, b2 (var x2))
 
   let lambda tp (f : Expr.t -> Expr.t) =
-      let x = fresh() in
+      let x = Ident.fresh() in
       Expr.Lam (x, tp, f (var x))
   let (@) e1 e2 = Expr.Apply (e1, e2)
 
@@ -258,13 +254,6 @@ end
 module Eval (S : SCALARS) = struct
   open S
   open Val
-
-  (* variable environment *)
-  module VarEnv = LambdaC.VariableEnvironment
-  let var_env : VarEnv.t ref = {contents = VarEnv.init}
-  let set_variable_environment (env : VarEnv.t) = var_env := env
-  let fresh () : Variable.t = VarEnv.fresh !var_env
-
 
   (* phase environment *)
 

--- a/lib/lambdaPC/lambdaPC.mli
+++ b/lib/lambdaPC/lambdaPC.mli
@@ -67,15 +67,14 @@ module SymplecticForm : sig
   val omega : Type.t -> LambdaC.Expr.t -> LambdaC.Expr.t -> LambdaC.Expr.t 
 end
 
-module PhaseEnvironment : (Zd : Scalars.Z_SIG) ->
+module PhaseEnvironment : functor (Zd : Scalars.Z_SIG) ->
     sig
       type t = Zd.t ref
       val init : t
       val add_phase : t -> Zd.t -> unit
       val add_integer_phase : t -> int -> unit
     end
-module Eval :
-  (S : Scalars.SCALARS) ->
+module Eval : functor (S : Scalars.SCALARS) ->
     sig
       module VarEnv = LambdaC.VariableEnvironment
       val var_env : VarEnv.t ref

--- a/lib/lambdaPC/lambdaPC.mli
+++ b/lib/lambdaPC/lambdaPC.mli
@@ -1,17 +1,17 @@
+open Ident
+
 module Type : sig
     type t = Pauli | PTensor of t*t
     val ltype_of_t : t -> LambdaC.Type.t
     val t_of_ltype : LambdaC.Type.t -> t option
     val string_of_t : t -> string
 end
-module Variable = LambdaC.Variable
-module VariableMap = LambdaC.VariableMap
 module Expr :
   sig
     type t =
-        Var of Variable.t
+        Var of Ident.t
       | Annot of t * Type.t
-      | Let of t * Variable.t * t
+      | Let of t * Ident.t * t
       | LExpr of LambdaC.Expr.t
       | Phase of LambdaC.Expr.t * t
       | Prod of t * t
@@ -19,10 +19,10 @@ module Expr :
       | CasePauli of t * t * t
       | In1 of t * Type.t
       | In2 of Type.t * t
-      | CasePTensor of t * Variable.t * t * Variable.t * t
+      | CasePTensor of t * Ident.t * t * Ident.t * t
       | Apply of pc * t
       | Force of p
-    and pc = Lam of (Variable.t * Type.t * t)
+    and pc = Lam of (Ident.t * Type.t * t)
     and p = Suspend of t
 
     val string_of_t : t -> string
@@ -32,7 +32,7 @@ module Expr :
     val pretty_string_of_pc : pc -> string
     val pretty_string_of_p : p -> string
 
-    val rename_var : int -> int -> t -> t
+    val rename_var : Ident.t -> Ident.t -> t -> t
   end
 module Val :
   sig
@@ -42,9 +42,8 @@ module Val :
   end
 
 module HOAS : sig
-  val fresh : unit -> Variable.t
 
-  val var : Variable.t -> Expr.t
+  val var : Ident.t -> Expr.t
   val letin : Expr.t -> (Expr.t -> Expr.t) -> Expr.t
   val vec : LambdaC.Expr.t -> Expr.t
   val phase : LambdaC.Expr.t -> Expr.t -> Expr.t
@@ -76,14 +75,8 @@ module PhaseEnvironment : functor (Zd : Scalars.Z_SIG) ->
     end
 module Eval : functor (S : Scalars.SCALARS) ->
     sig
-      module VarEnv = LambdaC.VariableEnvironment
-      val var_env : VarEnv.t ref
-      val set_variable_environment : VarEnv.t -> unit
-      val fresh : unit -> int
       module LEval :
         sig
-          val var_env : VarEnv.t ref
-          val set_variable_environment : VarEnv.t -> unit
           val vzero : LambdaC.Type.t -> LambdaC.Val.t
           val vplus : LambdaC.Val.t -> LambdaC.Val.t -> LambdaC.Val.t
           val vscale : int -> LambdaC.Val.t -> LambdaC.Val.t
@@ -93,8 +86,6 @@ module Eval : functor (S : Scalars.SCALARS) ->
         end
       module LEval' :
         sig
-          val var_env : VarEnv.t ref
-          val set_variable_environment : VarEnv.t -> unit
           val vzero : LambdaC.Type.t -> LambdaC.Val.t
           val vplus : LambdaC.Val.t -> LambdaC.Val.t -> LambdaC.Val.t
           val vscale : int -> LambdaC.Val.t -> LambdaC.Val.t

--- a/test/test_lambdaC.ml
+++ b/test/test_lambdaC.ml
@@ -1,5 +1,6 @@
 open Alcotest
 open PCLib
+open Ident
 open Scalars
 open LambdaC
 open Test_scalars
@@ -33,24 +34,29 @@ module TestEval2 = TestEval(Z2)
 
 (* Additional unit tests for individual functions in LambdaC *)
 let test_expr_rename_var () =
-  let e1_test = Expr.(Lambda (1, Unit, Plus (Var 1, Var 2))) in
-  let e1' = Expr.rename_var 2 42 e1_test in
-  let e1_expected = Expr.Lambda(1, Unit, Plus (Var 1, Var 42)) in
+  let x1 = Ident.fresh() in
+  let x2 = Ident.fresh() in
+  let x3 = Ident.fresh() in
+  let e1_test = Expr.(Lambda (x1, Unit, Plus (Var x1, Var x2))) in
+  let e1' = Expr.rename_var x2 x3 e1_test in
+  let e1_expected = Expr.Lambda(x1, Unit, Plus (Var x1, Var x3)) in
   (* ensure only free occurrences renamed, bound var 1 unchanged *)
   check string "rename_var_free" (Expr.string_of_t e1') (Expr.string_of_t e1_expected);
 
-  let e2' = Expr.rename_var 1 42 e1_test in
+  let e2' = Expr.rename_var x1 x3 e1_test in
   check string "rename_var_bound" (Expr.string_of_t e2') (Expr.string_of_t e1_test)
 
 let test_expr_map_and_val_map () =
-  let e1 = Expr.(Plus (Const 3, Scale (Const 2, Var 5))) in
+  let x0 = Ident.fresh() in
+  let e1 = Expr.(Plus (Const 3, Scale (Const 2, Var x0))) in
   let e1_mapped = Expr.map (fun x -> x + 1) e1 in
-  let e1_expected = Expr.(Plus (Const 4, Scale (Const 3, Var 5))) in
+  let e1_expected = Expr.(Plus (Const 4, Scale (Const 3, Var x0))) in
   check string "expr_map" (Expr.string_of_t e1_mapped) (Expr.string_of_t e1_expected);
 
-  let v1 = Val.(Pair (Const 3, Val.Lambda (7, Unit, Const 2))) in
+  let x1 = Ident.fresh() in
+  let v1 = Val.(Pair (Const 3, Val.Lambda (x1, Unit, Const 2))) in
   let v1_mapped = Val.map (fun x -> x * 2) v1 in
-  let v1_expected = Val.(Pair (Const 6, Lambda (7, Unit, Const 4))) in
+  let v1_expected = Val.(Pair (Const 6, Lambda (x1, Unit, Const 4))) in
   check string "val_map" (Val.string_of_t v1_mapped) (Val.string_of_t v1_expected)
 
 let test_vzero_vplus_vscale_case_apply () =
@@ -80,6 +86,7 @@ let test_symplectic_form () =
   (* For Z2, 1*1 - 0*0 = 1 *)
   check int "symplectic_form" (Z2.int_of_t z) 1
 
+(*
 let test_fresh_api_seed_then_allocate () =
   let reserved = Fresh.current () + 25 in
   Fresh.seed reserved;
@@ -102,7 +109,7 @@ let test_eval_fresh_uses_seeded_allocator () =
       check bool "vzero binder is fresh" true (x > 7000)
   | v ->
       failf "Unexpected vzero arrow result: %s\n" (Val.string_of_t v)
-
+*)
 let suite =
   [ "TestEvalZ2", [
       test_case "Testing 5+3 = 8"   `Quick (fun () -> 
@@ -130,8 +137,10 @@ let suite =
       test_case "Expr.map and Val.map" `Quick test_expr_map_and_val_map;
       test_case "vzero/vplus/vscale/Case/Apply" `Quick test_vzero_vplus_vscale_case_apply;
       test_case "symplectic_form" `Quick test_symplectic_form;
+      (*
       test_case "Fresh API seed then allocate" `Quick test_fresh_api_seed_then_allocate;
       test_case "Expr.update_env seeds freshness" `Quick test_expr_update_env_seeds_fresh;
       test_case "Eval uses seeded freshness" `Quick test_eval_fresh_uses_seeded_allocator;
+      *)
     ];
   ]

--- a/test/test_lambdaPC.ml
+++ b/test/test_lambdaPC.ml
@@ -68,12 +68,14 @@ let test_named_ast_seed_fresh_expr () =
       failf "Expected let-bound surface term, got %s\n"
         (LambdaPC_Surface.pretty_string_of_expr ast)
 
+(*
 let test_lambdapc_update_env_seeds_fresh () =
   let env = LambdaC.VariableEnvironment.create () in
   let pc = LambdaPC.Expr.Lam (9000, LambdaPC.Type.Pauli, LambdaPC.Expr.Var 9000) in
   LambdaPC.Expr.update_env_pc env pc;
   let x = LambdaPC.HOAS.fresh () in
   check bool "fresh is above LambdaPC binder" true (x > 9000)
+*)
 
 let suite =
   ["TestPCZ2", [
@@ -82,6 +84,6 @@ let suite =
     test_case "Parser accepts braced injections" `Quick test_parse_braced_injections;
     test_case "Parser reports resolve errors" `Quick test_parse_reports_resolve_errors;
     test_case "Named_ast seed_fresh seeds surface binders" `Quick test_named_ast_seed_fresh_expr;
-    test_case "LambdaPC update_env seeds freshness" `Quick test_lambdapc_update_env_seeds_fresh;
+    (*test_case "LambdaPC update_env seeds freshness" `Quick test_lambdapc_update_env_seeds_fresh;*)
     ];
   ] 


### PR DESCRIPTION
I know we want to eventually update LambdaC and LambdaPC to use Interface/named_ast, but for now I just updated the languages’ asts to use the common Ident.t. This led to a few questions that I’ll use this PR to ask.

Overall it went really well and I really like the interface!